### PR TITLE
update search_path with user schemas

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,15 @@ import os
 import pytest
 import pytest_pgsql
 
+from tipg.settings import CustomSQLSettings, DatabaseSettings, PostgresSettings
+
+from fastapi import FastAPI
+
 from starlette.testclient import TestClient
 
-DATA_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
-
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+TEMPLATE_DIRECTORY = os.path.join(FIXTURES_DIR, "templates")
+SQL_FUNCTIONS_DIRECTORY = os.path.join(FIXTURES_DIR, "functions")
 
 test_db = pytest_pgsql.TransactedPostgreSQLTestDB.create_fixture(
     "test_db", scope="session", use_restore_state=False
@@ -27,13 +32,13 @@ def database_url(test_db):
     # make sure we have a `public` schema
     test_db.create_schema("public", exists_ok=True)
 
-    test_db.run_sql_file(os.path.join(DATA_DIR, "landsat_wrs.sql"))
+    test_db.run_sql_file(os.path.join(FIXTURES_DIR, "landsat_wrs.sql"))
     assert test_db.has_table("public.landsat_wrs")
 
-    test_db.run_sql_file(os.path.join(DATA_DIR, "my_data.sql"))
+    test_db.run_sql_file(os.path.join(FIXTURES_DIR, "my_data.sql"))
     assert test_db.has_table("public.my_data")
 
-    test_db.run_sql_file(os.path.join(DATA_DIR, "nongeo_data.sql"))
+    test_db.run_sql_file(os.path.join(FIXTURES_DIR, "nongeo_data.sql"))
     assert test_db.has_table("public.nongeo_data")
 
     test_db.connection.execute(
@@ -51,11 +56,11 @@ def database_url(test_db):
     assert count_landsat == count_landsat_centroid
 
     # Add table with Huge geometries
-    test_db.run_sql_file(os.path.join(DATA_DIR, "canada.sql"))
+    test_db.run_sql_file(os.path.join(FIXTURES_DIR, "canada.sql"))
     assert test_db.has_table("public.canada")
 
     # add table with geometries not in WGS84
-    test_db.run_sql_file(os.path.join(DATA_DIR, "minnesota.sql"))
+    test_db.run_sql_file(os.path.join(FIXTURES_DIR, "minnesota.sql"))
     assert test_db.has_table("public.minnesota")
 
     # add a `myschema` schema
@@ -71,17 +76,68 @@ def database_url(test_db):
     ).scalar()
     assert count_landsat == count_landsat_schema
 
-    return test_db.connection.engine.url
+    return str(test_db.connection.engine.url)
+
+
+def create_tipg_app(
+    postgres_settings: PostgresSettings,
+    db_settings: DatabaseSettings,
+    sql_settings: CustomSQLSettings,
+) -> FastAPI:
+    """Create TiPG Application."""
+
+    from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
+    from tipg.factory import Endpoints
+
+    app = FastAPI(
+        title="TiPg: OGC Features and Tiles API",
+        openapi_url="/api",
+        docs_url="/api.html",
+    )
+    ogc_api = Endpoints(title="TiPg: OGC Features and Tiles API")
+    app.include_router(ogc_api.router)
+
+    @app.on_event("startup")
+    async def startup_event() -> None:
+        """Connect to database on startup."""
+        await connect_to_db(
+            app,
+            settings=postgres_settings,
+            schemas=db_settings.user_schemas,
+            user_sql_files=sql_settings.sql_files,
+        )
+        await register_collection_catalog(
+            app,
+            schemas=db_settings.schemas,
+            exclude_schemas=db_settings.exclude_schemas,
+            tables=db_settings.tables,
+            exclude_tables=db_settings.exclude_tables,
+            function_schemas=db_settings.function_schemas,
+            exclude_function_schemas=db_settings.exclude_function_schemas,
+            functions=db_settings.functions,
+            exclude_functions=db_settings.exclude_functions,
+            spatial=db_settings.only_spatial_tables,
+        )
+
+    @app.on_event("shutdown")
+    async def shutdown_event() -> None:
+        """Close database connection."""
+        await close_db_connection(app)
+
+    return app
 
 
 @pytest.fixture(autouse=True)
 def app(database_url, monkeypatch):
     """Create app with connection to the pytest database."""
-    monkeypatch.setenv("DATABASE_URL", str(database_url))
+    monkeypatch.setenv("DATABASE_URL", database_url)
     monkeypatch.setenv("ONLY_SPATIAL_TABLES", "FALSE")
 
     # API config
-    monkeypatch.setenv("TIPG_TEMPLATE_DIRECTORY", os.path.join(DATA_DIR, "templates"))
+    monkeypatch.setenv("TIPG_TEMPLATE_DIRECTORY", TEMPLATE_DIRECTORY)
+
+    # Custom Functions
+    monkeypatch.setenv("TIPG_CUSTOM_SQL_DIRECTORY", SQL_FUNCTIONS_DIRECTORY)
 
     # Tables configs
     monkeypatch.setenv("TIPG_TABLE_CONFIG__public_my_data__datetimecol", "datetime")
@@ -92,16 +148,13 @@ def app(database_url, monkeypatch):
     monkeypatch.setenv("TIPG_TABLE_CONFIG__public_my_data_alt__pk", "id")
     monkeypatch.setenv("TIPG_TABLE_CONFIG__public_landsat__geomcol", "geom")
 
-    # Custom Functions
-    monkeypatch.setenv("TIPG_CUSTOM_SQL_DIRECTORY", os.path.join(DATA_DIR, "functions"))
-
     # OGC Tiles Settings
     monkeypatch.setenv("TIPG_DEFAULT_MINZOOM", str(5))
     monkeypatch.setenv("TIPG_DEFAULT_MAXZOOM", str(12))
 
     from tipg.main import app, db_settings, postgres_settings
 
-    postgres_settings.database_url = str(database_url)
+    postgres_settings.database_url = database_url
 
     db_settings.only_spatial_tables = False
     db_settings.exclude_tables = None
@@ -116,170 +169,172 @@ def app(database_url, monkeypatch):
         yield app
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_excludes(database_url, monkeypatch):
-    """Create app with connection to the pytest database."""
+    """Create APP with but excludes `public.nongeo_data` table."""
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["public"],
+        exclude_tables=["public.nongeo_data"],
+        functions=[],
+        only_spatial_tables=False,
+    )
+    assert db_settings.user_schemas == ["public"]
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    from tipg.main import app, db_settings, postgres_settings
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.exclude_tables = ["public.nongeo_data"]
-    db_settings.tables = None
-    db_settings.functions = []
-
-    assert db_settings.exclude_tables == ["public.nongeo_data"]
-
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
-
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_includes(database_url, monkeypatch):
-    """Create app with connection to the pytest database."""
+    """Create APP with only `public.nongeo_data` table."""
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["public"],
+        tables=["public.nongeo_data"],
+        functions=[],
+        only_spatial_tables=False,
+    )
+    assert db_settings.user_schemas == ["public"]
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    from tipg.main import app, db_settings, postgres_settings
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.exclude_tables = None
-    db_settings.tables = ["public.nongeo_data"]
-    db_settings.functions = []
-
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
-
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
-def app_myschema(database_url, monkeypatch):
+@pytest.fixture
+def app_myschema(database_url):
     """Create APP with only tables from `myschema` schema and no function schema.
 
     Available tables should come from `myschema` and functions from `pg_temp`.
     """
-
-    from tipg.main import app, db_settings, postgres_settings
-
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.schemas = ["myschema"]
-    db_settings.function_schemas = []
-
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["myschema"],
+        function_schemas=[],
+        only_spatial_tables=False,
+    )
     assert db_settings.user_schemas == ["myschema"]
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_myschema_public(database_url, monkeypatch):
     """Create APP with only tables from `myschema` and `public` schema and no function schema.
 
     Available tables should come from `myschema` and `public` and functions from `pg_temp`.
     """
-
-    from tipg.main import app, db_settings, postgres_settings
-
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.schemas = ["myschema", "public"]
-    db_settings.function_schemas = []
-
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["myschema", "public"],
+        function_schemas=[],
+        only_spatial_tables=False,
+    )
     assert sorted(db_settings.user_schemas) == sorted(["public", "myschema"])
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_myschema_public_functions(database_url, monkeypatch):
     """Create APP with only tables from `myschema` schema and functions from `public` schema.
 
     Available tables should come from `myschema` and functions from `pg_temp` and `public` schema.
     """
-
-    from tipg.main import app, db_settings, postgres_settings
-
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.schemas = ["myschema"]
-    db_settings.function_schemas = ["public"]
-
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["myschema"],
+        function_schemas=["public"],
+        only_spatial_tables=False,
+    )
     assert sorted(db_settings.user_schemas) == sorted(["public", "myschema"])
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_only_public_functions(database_url, monkeypatch):
     """Create APP with only functions from `pg_temp`and `public` schemas.
 
     Available functions from `pg_temp` and `public` schema (no tables available).
     """
-
-    from tipg.main import app, db_settings, postgres_settings
-
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.schemas = []
-    db_settings.function_schemas = ["public"]
-
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=[],
+        function_schemas=["public"],
+        only_spatial_tables=False,
+    )
     assert sorted(db_settings.user_schemas) == sorted(["public"])
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def app_myschema_public_order(database_url, monkeypatch):
     """Create APP with only tables from `myschema` and `public` schema and no function schema (different order).
 
     Available tables should come from `myschema` and `public` and functions from `pg_temp`.
     """
-
-    from tipg.main import app, db_settings, postgres_settings
-
-    postgres_settings.database_url = str(database_url)
-
-    db_settings.only_spatial_tables = False
-    db_settings.schemas = ["public", "myschema"]
-    db_settings.function_schemas = []
-
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["public", "myschema"],
+        function_schemas=[],
+        only_spatial_tables=False,
+    )
     assert sorted(db_settings.user_schemas) == sorted(["public", "myschema"])
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
-    # Remove middlewares https://github.com/encode/starlette/issues/472
-    app.user_middleware = []
-    app.middleware_stack = app.build_middleware_stack()
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
 
-    with TestClient(app) as app:
-        yield app
+    with TestClient(app) as client:
+        yield client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,10 @@ def app_includes(database_url, monkeypatch):
 
 @pytest.fixture()
 def app_myschema(database_url, monkeypatch):
-    """Create app with connection to the pytest database."""
+    """Create APP with only tables from `myschema` schema and no function schema.
+
+    Available tables should come from `myschema` and functions from `pg_temp`.
+    """
 
     from tipg.main import app, db_settings, postgres_settings
 
@@ -184,7 +187,10 @@ def app_myschema(database_url, monkeypatch):
 
 @pytest.fixture()
 def app_myschema_public(database_url, monkeypatch):
-    """Create app with connection to the pytest database."""
+    """Create APP with only tables from `myschema` and `public` schema and no function schema.
+
+    Available tables should come from `myschema` and `public` and functions from `pg_temp`.
+    """
 
     from tipg.main import app, db_settings, postgres_settings
 
@@ -206,7 +212,10 @@ def app_myschema_public(database_url, monkeypatch):
 
 @pytest.fixture()
 def app_myschema_public_functions(database_url, monkeypatch):
-    """Create app with connection to the pytest database."""
+    """Create APP with only tables from `myschema` schema and functions from `public` schema.
+
+    Available tables should come from `myschema` and functions from `pg_temp` and `public` schema.
+    """
 
     from tipg.main import app, db_settings, postgres_settings
 
@@ -215,6 +224,56 @@ def app_myschema_public_functions(database_url, monkeypatch):
     db_settings.only_spatial_tables = False
     db_settings.schemas = ["myschema"]
     db_settings.function_schemas = ["public"]
+
+    assert sorted(db_settings.user_schemas) == sorted(["public", "myschema"])
+
+    # Remove middlewares https://github.com/encode/starlette/issues/472
+    app.user_middleware = []
+    app.middleware_stack = app.build_middleware_stack()
+
+    with TestClient(app) as app:
+        yield app
+
+
+@pytest.fixture()
+def app_only_public_functions(database_url, monkeypatch):
+    """Create APP with only functions from `pg_temp`and `public` schemas.
+
+    Available functions from `pg_temp` and `public` schema (no tables available).
+    """
+
+    from tipg.main import app, db_settings, postgres_settings
+
+    postgres_settings.database_url = str(database_url)
+
+    db_settings.only_spatial_tables = False
+    db_settings.schemas = []
+    db_settings.function_schemas = ["public"]
+
+    assert sorted(db_settings.user_schemas) == sorted(["public"])
+
+    # Remove middlewares https://github.com/encode/starlette/issues/472
+    app.user_middleware = []
+    app.middleware_stack = app.build_middleware_stack()
+
+    with TestClient(app) as app:
+        yield app
+
+
+@pytest.fixture()
+def app_myschema_public_order(database_url, monkeypatch):
+    """Create APP with only tables from `myschema` and `public` schema and no function schema (different order).
+
+    Available tables should come from `myschema` and `public` and functions from `pg_temp`.
+    """
+
+    from tipg.main import app, db_settings, postgres_settings
+
+    postgres_settings.database_url = str(database_url)
+
+    db_settings.only_spatial_tables = False
+    db_settings.schemas = ["public", "myschema"]
+    db_settings.function_schemas = []
 
     assert sorted(db_settings.user_schemas) == sorted(["public", "myschema"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,3 +305,27 @@ def app_only_public_functions(database_url, monkeypatch):
 
     with TestClient(app) as client:
         yield client
+
+
+@pytest.fixture
+def app_myschema_public_order(database_url, monkeypatch):
+    """Create APP with only tables from `myschema` and `public` schema and no function schema.
+
+    Available tables should come from `myschema` and `public` and functions from `pg_temp`.
+    """
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["public", "myschema"],
+        exclude_function_schemas=["public"],
+        only_spatial_tables=False,
+    )
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
+
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
+
+    with TestClient(app) as client:
+        yield client

--- a/tests/routes/test_collections.py
+++ b/tests/routes/test_collections.py
@@ -66,12 +66,14 @@ def test_collections_search(app):
     body = response.json()
     assert body["numberMatched"] == 4
     ids = [x["id"] for x in body["collections"]]
-    assert [
-        "public.my_data",
-        "public.my_data_alt",
-        "public.my_data_geo",
-        "public.nongeo_data",
-    ] == ids
+    assert sorted(
+        [
+            "public.my_data",
+            "public.my_data_alt",
+            "public.my_data_geo",
+            "public.nongeo_data",
+        ]
+    ) == sorted(ids)
 
     response = app.get("/collections", params={"datetime": "2022-12-31T23:59:59Z/.."})
     body = response.json()
@@ -81,18 +83,22 @@ def test_collections_search(app):
     body = response.json()
     assert body["numberMatched"] == 4
     ids = [x["id"] for x in body["collections"]]
-    assert [
-        "public.my_data",
-        "public.my_data_alt",
-        "public.my_data_geo",
-        "public.nongeo_data",
-    ] == ids
+    assert sorted(
+        [
+            "public.my_data",
+            "public.my_data_alt",
+            "public.my_data_geo",
+            "public.nongeo_data",
+        ]
+    ) == sorted(ids)
 
     response = app.get("/collections", params={"datetime": "2004-12-31T23:59:59Z/.."})
     body = response.json()
     assert body["numberMatched"] == 3
     ids = [x["id"] for x in body["collections"]]
-    assert ["public.my_data", "public.my_data_alt", "public.my_data_geo"] == ids
+    assert sorted(
+        ["public.my_data", "public.my_data_alt", "public.my_data_geo"]
+    ) == sorted(ids)
 
     response = app.get(
         "/collections", params={"datetime": "2004-01-01T00:00:00Z/2004-12-31T23:59:59Z"}

--- a/tests/routes/test_schemas.py
+++ b/tests/routes/test_schemas.py
@@ -1,15 +1,14 @@
 """Test /collections endpoints."""
 
 
-def test_collections_myschema(app_myschema):
-    """Test /collections endpoint."""
+def test_myschema(app_myschema):
+    """Available tables should come from `myschema` and functions from `pg_temp`."""
     collection_number = 4  # 3 custom functions + 1 tables from myschema
 
     response = app_myschema.get("/collections")
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
     body = response.json()
-    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
     ids = [x["id"] for x in body["collections"]]
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
@@ -22,19 +21,17 @@ def test_collections_myschema(app_myschema):
     assert body["numberMatched"] == collection_number
 
 
-def test_collections_myschema_and_public_functions(app_myschema_public_functions):
-    """Test /collections endpoint."""
+def test_myschema_and_public_functions(app_myschema_public_functions):
+    """Available tables should come from `myschema` and functions from `pg_temp` and `public` schema."""
     collection_number = (
         7  # 3 custom functions + 1 tables from myschema + 3 functions from public
     )
 
     response = app_myschema_public_functions.get("/collections")
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/json"
     body = response.json()
-    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
-
     ids = [x["id"] for x in body["collections"]]
+
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
     assert "pg_temp.squares" in ids
@@ -51,19 +48,71 @@ def test_collections_myschema_and_public_functions(app_myschema_public_functions
     assert body["numberMatched"] == collection_number
 
 
-def test_collections_myschema_and_public(app_myschema_public):
-    """Test /collections endpoint."""
+def test_myschema_and_public(app_myschema_public):
+    """Available tables should come from `myschema` and `public` and functions from `pg_temp`"""
     collection_number = (
-        10  # 3 custom functions + 1 tables from myschema + 6 tables from public
+        11  # 3 custom functions + 1 tables from myschema + 7 tables from public
     )
 
     response = app_myschema_public.get("/collections")
     assert response.status_code == 200
-    assert response.headers["content-type"] == "application/json"
     body = response.json()
-    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
-
     ids = [x["id"] for x in body["collections"]]
+
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+
+    # myschema table
+    assert "myschema.landsat" in ids
+
+    # tables from public
+    assert "public.my_data" in ids
+
+    # no public functions
+    assert "public.st_hexagongrid" not in ids
+
+    assert body["numberMatched"] == collection_number
+
+
+def test_public_functions(app_only_public_functions):
+    """Available functions from `pg_temp` and `public` schema (no tables available)."""
+    collection_number = 6  # 3 custom functions + 3 functions from public
+
+    response = app_only_public_functions.get("/collections")
+    assert response.status_code == 200
+    body = response.json()
+    ids = [x["id"] for x in body["collections"]]
+
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+
+    # public functions
+    assert "public.st_hexagongrid" in ids
+
+    # no myschema table
+    assert "myschema.landsat" not in ids
+
+    # no tables from public
+    assert "public.my_data" not in ids
+
+    assert body["numberMatched"] == collection_number
+
+
+def test_myschema_and_public_order(app_myschema_public_order):
+    """Available tables should come from `myschema` and `public` and functions from `pg_temp`"""
+    collection_number = (
+        11  # 3 custom functions + 7 tables from public + 1 tables from myschema
+    )
+
+    response = app_myschema_public_order.get("/collections")
+    assert response.status_code == 200
+    body = response.json()
+    ids = [x["id"] for x in body["collections"]]
+
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
     assert "pg_temp.squares" in ids

--- a/tests/routes/test_schemas.py
+++ b/tests/routes/test_schemas.py
@@ -1,0 +1,80 @@
+"""Test /collections endpoints."""
+
+
+def test_collections_myschema(app_myschema):
+    """Test /collections endpoint."""
+    collection_number = 4  # 3 custom functions + 1 tables from myschema
+
+    response = app_myschema.get("/collections")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    body = response.json()
+    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
+    assert body["numberMatched"] == collection_number
+    assert body["numberReturned"] == collection_number
+    ids = [x["id"] for x in body["collections"]]
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+
+    # myschema table
+    assert "myschema.landsat" in ids
+
+
+def test_collections_myschema_and_public_functions(app_myschema_public_functions):
+    """Test /collections endpoint."""
+    collection_number = (
+        7  # 3 custom functions + 1 tables from myschema + 3 functions from public
+    )
+
+    response = app_myschema_public_functions.get("/collections")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    body = response.json()
+    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
+    assert body["numberMatched"] == collection_number
+    assert body["numberReturned"] == collection_number
+    ids = [x["id"] for x in body["collections"]]
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+    # public functions
+    assert "public.st_hexagongrid" in ids
+
+    # myschema table
+    assert "myschema.landsat" in ids
+
+    # no tables from public
+    assert "public.my_data" not in ids
+
+
+def test_collections_myschema_and_public(app_myschema_public):
+    """Test /collections endpoint."""
+    collection_number = (
+        10  # 3 custom functions + 1 tables from myschema + 6 tables from public
+    )
+
+    response = app_myschema_public.get("/collections")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/json"
+    body = response.json()
+    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
+    assert body["numberMatched"] == collection_number
+    assert body["numberReturned"] == collection_number
+    ids = [x["id"] for x in body["collections"]]
+    print(ids)
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+
+    # myschema table
+    assert "myschema.landsat" in ids
+
+    # tables from public
+    assert "public.my_data" in ids
+
+    # no public functions
+    assert "public.st_hexagongrid" not in ids

--- a/tests/routes/test_schemas.py
+++ b/tests/routes/test_schemas.py
@@ -10,8 +10,6 @@ def test_collections_myschema(app_myschema):
     assert response.headers["content-type"] == "application/json"
     body = response.json()
     assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
-    assert body["numberMatched"] == collection_number
-    assert body["numberReturned"] == collection_number
     ids = [x["id"] for x in body["collections"]]
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
@@ -20,6 +18,8 @@ def test_collections_myschema(app_myschema):
 
     # myschema table
     assert "myschema.landsat" in ids
+
+    assert body["numberMatched"] == collection_number
 
 
 def test_collections_myschema_and_public_functions(app_myschema_public_functions):
@@ -33,8 +33,7 @@ def test_collections_myschema_and_public_functions(app_myschema_public_functions
     assert response.headers["content-type"] == "application/json"
     body = response.json()
     assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
-    assert body["numberMatched"] == collection_number
-    assert body["numberReturned"] == collection_number
+
     ids = [x["id"] for x in body["collections"]]
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
@@ -49,6 +48,8 @@ def test_collections_myschema_and_public_functions(app_myschema_public_functions
     # no tables from public
     assert "public.my_data" not in ids
 
+    assert body["numberMatched"] == collection_number
+
 
 def test_collections_myschema_and_public(app_myschema_public):
     """Test /collections endpoint."""
@@ -61,10 +62,8 @@ def test_collections_myschema_and_public(app_myschema_public):
     assert response.headers["content-type"] == "application/json"
     body = response.json()
     assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
-    assert body["numberMatched"] == collection_number
-    assert body["numberReturned"] == collection_number
+
     ids = [x["id"] for x in body["collections"]]
-    print(ids)
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
     assert "pg_temp.squares" in ids
@@ -78,3 +77,5 @@ def test_collections_myschema_and_public(app_myschema_public):
 
     # no public functions
     assert "public.st_hexagongrid" not in ids
+
+    assert body["numberMatched"] == collection_number

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,4 +1,4 @@
-"""Test /collections endpoints."""
+"""Test schemas."""
 
 
 def test_myschema(app_myschema):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -100,31 +100,3 @@ def test_public_functions(app_only_public_functions):
     assert "public.my_data" not in ids
 
     assert body["numberMatched"] == collection_number
-
-
-def test_myschema_and_public_order(app_myschema_public_order):
-    """Available tables should come from `myschema` and `public` and functions from `pg_temp`"""
-    collection_number = (
-        11  # 3 custom functions + 7 tables from public + 1 tables from myschema
-    )
-
-    response = app_myschema_public_order.get("/collections")
-    assert response.status_code == 200
-    body = response.json()
-    ids = [x["id"] for x in body["collections"]]
-
-    # custom functions
-    assert "pg_temp.landsat_centroids" in ids
-    assert "pg_temp.squares" in ids
-    assert "pg_temp.hexagons" in ids
-
-    # myschema table
-    assert "myschema.landsat" in ids
-
-    # tables from public
-    assert "public.my_data" in ids
-
-    # no public functions
-    assert "public.st_hexagongrid" not in ids
-
-    assert body["numberMatched"] == collection_number

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,6 +10,7 @@ def test_myschema(app_myschema):
     assert response.headers["content-type"] == "application/json"
     body = response.json()
     ids = [x["id"] for x in body["collections"]]
+
     # custom functions
     assert "pg_temp.landsat_centroids" in ids
     assert "pg_temp.squares" in ids
@@ -51,7 +52,7 @@ def test_myschema_and_public_functions(app_myschema_public_functions):
 def test_myschema_and_public(app_myschema_public):
     """Available tables should come from `myschema` and `public` and functions from `pg_temp`"""
     collection_number = (
-        11  # 3 custom functions + 1 tables from myschema + 7 tables from public
+        12  # 3 custom functions + 1 tables from myschema + 8 tables from public
     )
 
     response = app_myschema_public.get("/collections")
@@ -69,6 +70,13 @@ def test_myschema_and_public(app_myschema_public):
 
     # tables from public
     assert "public.my_data" in ids
+    assert "public.my_data_alt" in ids
+    assert "public.minnesota" in ids
+    assert "public.canada" in ids
+    assert "public.landsat" in ids
+    assert "public.nongeo_data" in ids
+    assert "public.my_data_geo" in ids
+    assert "public.landsat_wrs" in ids
 
     # no public functions
     assert "public.st_hexagongrid" not in ids

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -108,3 +108,31 @@ def test_public_functions(app_only_public_functions):
     assert "public.my_data" not in ids
 
     assert body["numberMatched"] == collection_number
+
+
+def test_myschema_and_public_order(app_myschema_public_order):
+    """Available tables should come from `myschema` and `public` and functions from `pg_temp`"""
+    collection_number = (
+        12  # 3 custom functions + 1 tables from myschema + 8 tables from public
+    )
+
+    response = app_myschema_public_order.get("/collections")
+    assert response.status_code == 200
+    body = response.json()
+    ids = [x["id"] for x in body["collections"]]
+
+    # custom functions
+    assert "pg_temp.landsat_centroids" in ids
+    assert "pg_temp.squares" in ids
+    assert "pg_temp.hexagons" in ids
+
+    # myschema table
+    assert "myschema.landsat" in ids
+
+    # tables from public
+    assert "public.my_data" in ids
+
+    # no public functions
+    assert "public.st_hexagongrid" not in ids
+
+    assert body["numberMatched"] == collection_number

--- a/tipg/db.py
+++ b/tipg/db.py
@@ -46,12 +46,12 @@ class con_init:
         await conn.set_type_codec(
             "jsonb", encoder=orjson.dumps, decoder=orjson.loads, schema="pg_catalog"
         )
-        schemas = ",".join(self.schemas + ["pg_temp"]) + ","
+        schemas = ",".join(["pg_temp"] + self.schemas)
         await conn.execute(
             f"""
             SELECT set_config(
                 'search_path',
-                '{schemas}' || current_setting('search_path', false),
+                '{schemas},' || current_setting('search_path', false),
                 false
                 );
             """

--- a/tipg/db.py
+++ b/tipg/db.py
@@ -7,8 +7,8 @@ import orjson
 from buildpg import asyncpg
 
 from tipg.dbmodel import get_collection_index
-from tipg.errors import FunctionDirectoryDoesNotExist
-from tipg.settings import CustomSQLSettings, PostgresSettings
+from tipg.logger import logger
+from tipg.settings import PostgresSettings
 
 from fastapi import FastAPI
 
@@ -18,25 +18,23 @@ except ImportError:
     # Try backported to PY<39 `importlib_resources`.
     from importlib_resources import files as resources_files  # type: ignore
 
-sql_settings = CustomSQLSettings()
+DB_CATALOG_FILE = resources_files(__package__) / "sql" / "dbcatalog.sql"
 
 
-custom_sql: List[pathlib.Path] = []
-if user_sql_dir := sql_settings.custom_sql_directory:
-    if not pathlib.Path(user_sql_dir).exists():
-        raise FunctionDirectoryDoesNotExist
-
-    custom_sql = list(pathlib.Path(user_sql_dir).glob("*.sql"))
-
-
-class con_init:
+class connection_factory:
     """Connection creation."""
 
     schemas: List[str]
+    user_sql_files: List[pathlib.Path]
 
-    def __init__(self, schemas: Optional[List[str]] = None) -> None:
+    def __init__(
+        self,
+        schemas: Optional[List[str]] = None,
+        user_sql_files: Optional[List[pathlib.Path]] = None,
+    ) -> None:
         """Init."""
         self.schemas = schemas or []
+        self.user_sql_files = user_sql_files or []
 
     async def __call__(self, conn: asyncpg.Connection):
         """Create connection."""
@@ -50,6 +48,7 @@ class con_init:
         # Note: we add `pg_temp as the first element of the schemas list to make sure
         # we register the custom functions and `dbcatalog` in it.
         schemas = ",".join(["pg_temp", *self.schemas])
+        logger.debug(f"Looking for Tables and Functions in {schemas} schemas")
 
         await conn.execute(
             f"""
@@ -62,24 +61,25 @@ class con_init:
         )
 
         # Register custom SQL functions/table/views in pg_temp
-        if custom_sql:
-            for sqlfile in custom_sql:
-                await conn.execute(sqlfile.read_text())
+        for sqlfile in self.user_sql_files:
+            await conn.execute(sqlfile.read_text())
 
         # Register TiPG functions in `pg_temp`
-        dbcatalogsql = resources_files(__package__) / "sql" / "dbcatalog.sql"
-        await conn.execute(dbcatalogsql.read_text())
+        await conn.execute(DB_CATALOG_FILE.read_text())
 
 
 async def connect_to_db(
     app: FastAPI,
     settings: Optional[PostgresSettings] = None,
     schemas: Optional[List[str]] = None,
+    user_sql_files: Optional[List[pathlib.Path]] = None,
     **kwargs,
 ) -> None:
     """Connect."""
     if not settings:
         settings = PostgresSettings()
+
+    con_init = connection_factory(schemas, user_sql_files)
 
     app.state.pool = await asyncpg.create_pool_b(
         settings.database_url,
@@ -87,7 +87,7 @@ async def connect_to_db(
         max_size=settings.db_max_conn_size,
         max_queries=settings.db_max_queries,
         max_inactive_connection_lifetime=settings.db_max_inactive_conn_lifetime,
-        init=con_init(schemas),
+        init=con_init,
         **kwargs,
     )
 

--- a/tipg/dbmodel.py
+++ b/tipg/dbmodel.py
@@ -873,13 +873,12 @@ Database = Dict[str, Collection]
 async def get_collection_index(  # noqa: C901
     db_pool: asyncpg.BuildPgPool,
     schemas: Optional[List[str]] = ["public"],
-    exclude_schemas: Optional[List[str]] = None,
     tables: Optional[List[str]] = None,
     exclude_tables: Optional[List[str]] = None,
-    function_schemas: Optional[List[str]] = ["public"],
-    exclude_function_schemas: Optional[List[str]] = None,
+    exclude_table_schemas: Optional[List[str]] = None,
     functions: Optional[List[str]] = None,
     exclude_functions: Optional[List[str]] = None,
+    exclude_function_schemas: Optional[List[str]] = None,
     spatial: bool = True,
 ) -> Database:
     """Fetch Table and Functions index."""
@@ -887,13 +886,12 @@ async def get_collection_index(  # noqa: C901
     query = """
         SELECT pg_temp.tipg_catalog(
             :schemas,
-            :exclude_schemas,
             :tables,
             :exclude_tables,
-            :function_schemas,
-            :exclude_function_schemas,
+            :exclude_table_schemas,
             :functions,
             :exclude_functions,
+            :exclude_function_schemas,
             :spatial
         );
     """  # noqa: W605
@@ -902,13 +900,12 @@ async def get_collection_index(  # noqa: C901
         rows = await conn.fetch_b(
             query,
             schemas=schemas,
-            exclude_schemas=exclude_schemas,
             tables=tables,
             exclude_tables=exclude_tables,
-            function_schemas=function_schemas,
-            exclude_function_schemas=exclude_function_schemas,
+            exclude_table_schemas=exclude_table_schemas,
             functions=functions,
             exclude_functions=exclude_functions,
+            exclude_function_schemas=exclude_function_schemas,
             spatial=spatial,
         )
 

--- a/tipg/dbmodel.py
+++ b/tipg/dbmodel.py
@@ -22,6 +22,7 @@ from tipg.errors import (
 )
 from tipg.filter.evaluate import to_filter
 from tipg.filter.filters import bbox_to_wkt
+from tipg.logger import logger
 from tipg.model import Extent
 from tipg.settings import MVTSettings, TableSettings
 
@@ -44,8 +45,7 @@ def debug_query(q, *p):
             return s
 
     p = [quote_str(s) for s in p]
-    print("DEBUG QUERY")
-    print(qsub.format(None, *p))
+    logger.debug(qsub.format(None, *p))
 
 
 # Links to geojson schema
@@ -353,7 +353,6 @@ class Collection(BaseModel):
         tile: Tile,
     ):
         """Create MVT from intersecting geometries."""
-        print(geometry_column.type)
         geom = pg_funcs.cast(logic.V(geometry_column.name), "geometry")
 
         # make sure the geometries do not overflow the TMS bbox

--- a/tipg/logger.py
+++ b/tipg/logger.py
@@ -1,0 +1,5 @@
+"""tipg logger."""
+
+import logging
+
+logger = logging.getLogger("tipg")

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -64,7 +64,9 @@ add_exception_handlers(app, DEFAULT_STATUS_CODES)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
-    await connect_to_db(app, settings=postgres_settings)
+    await connect_to_db(
+        app, settings=postgres_settings, schemas=db_settings.user_schemas
+    )
     await register_collection_catalog(
         app,
         schemas=db_settings.schemas,

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -9,7 +9,12 @@ from tipg.db import close_db_connection, connect_to_db, register_collection_cata
 from tipg.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from tipg.factory import Endpoints
 from tipg.middleware import CacheControlMiddleware
-from tipg.settings import APISettings, DatabaseSettings, PostgresSettings
+from tipg.settings import (
+    APISettings,
+    CustomSQLSettings,
+    DatabaseSettings,
+    PostgresSettings,
+)
 
 from fastapi import FastAPI, Request
 
@@ -20,6 +25,7 @@ from starlette_cramjam.middleware import CompressionMiddleware
 settings = APISettings()
 postgres_settings = PostgresSettings()
 db_settings = DatabaseSettings()
+custom_sql_settings = CustomSQLSettings()
 
 
 app = FastAPI(
@@ -65,7 +71,10 @@ add_exception_handlers(app, DEFAULT_STATUS_CODES)
 async def startup_event() -> None:
     """Connect to database on startup."""
     await connect_to_db(
-        app, settings=postgres_settings, schemas=db_settings.user_schemas
+        app,
+        settings=postgres_settings,
+        schemas=db_settings.user_schemas,
+        user_sql_files=custom_sql_settings.sql_files,
     )
     await register_collection_catalog(
         app,

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -73,19 +73,18 @@ async def startup_event() -> None:
     await connect_to_db(
         app,
         settings=postgres_settings,
-        schemas=db_settings.user_schemas,
+        schemas=db_settings.schemas,
         user_sql_files=custom_sql_settings.sql_files,
     )
     await register_collection_catalog(
         app,
         schemas=db_settings.schemas,
-        exclude_schemas=db_settings.exclude_schemas,
         tables=db_settings.tables,
         exclude_tables=db_settings.exclude_tables,
-        function_schemas=db_settings.function_schemas,
-        exclude_function_schemas=db_settings.exclude_function_schemas,
+        exclude_table_schemas=db_settings.exclude_table_schemas,
         functions=db_settings.functions,
         exclude_functions=db_settings.exclude_functions,
+        exclude_function_schemas=db_settings.exclude_function_schemas,
         spatial=db_settings.only_spatial_tables,
     )
 

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -158,6 +158,11 @@ class DatabaseSettings(pydantic.BaseSettings):
         env_prefix = "TIPG_DB_"
         env_file = ".env"
 
+    @property
+    def user_schemas(self) -> Optional[List[str]]:
+        """Return a set of schemas from tables/functions schemas."""
+        return list(set([*self.schemas, *self.function_schemas]))
+
 
 class CustomSQLSettings(pydantic.BaseSettings):
     """TiPg Custom SQL settings."""

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -141,13 +141,12 @@ class DatabaseSettings(pydantic.BaseSettings):
     """TiPg Database settings."""
 
     schemas: List[str] = ["public"]
-    exclude_schemas: Optional[List[str]]
     tables: Optional[List[str]]
     exclude_tables: Optional[List[str]]
-    function_schemas: List[str] = ["public"]
-    exclude_function_schemas: Optional[List[str]]
+    exclude_table_schemas: Optional[List[str]]
     functions: Optional[List[str]]
     exclude_functions: Optional[List[str]]
+    exclude_function_schemas: Optional[List[str]]
 
     only_spatial_tables: bool = True
 
@@ -156,11 +155,6 @@ class DatabaseSettings(pydantic.BaseSettings):
 
         env_prefix = "TIPG_DB_"
         env_file = ".env"
-
-    @property
-    def user_schemas(self) -> Optional[List[str]]:
-        """Return a set of schemas from tables/functions schemas."""
-        return list(set([*self.schemas, *self.function_schemas]))
 
 
 class CustomSQLSettings(pydantic.BaseSettings):

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -1,5 +1,6 @@
 """tipg config."""
 
+import pathlib
 import sys
 from typing import Any, Dict, List, Optional
 
@@ -165,10 +166,18 @@ class DatabaseSettings(pydantic.BaseSettings):
 class CustomSQLSettings(pydantic.BaseSettings):
     """TiPg Custom SQL settings."""
 
-    custom_sql_directory: Optional[str]
+    custom_sql_directory: Optional[pydantic.DirectoryPath]
 
     class Config:
         """model config"""
 
         env_prefix = "TIPG_"
         env_file = ".env"
+
+    @property
+    def sql_files(self) -> Optional[List[pathlib.Path]]:
+        """return a list of SQL files within the custom sql directory."""
+        if self.custom_sql_directory:
+            return list(self.custom_sql_directory.glob("*.sql"))
+
+        return None

--- a/tipg/sql/dbcatalog.sql
+++ b/tipg/sql/dbcatalog.sql
@@ -198,13 +198,12 @@ $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
     schemas text[] DEFAULT NULL,
-    exclude_schemas text[] DEFAULT NULL,
     tables text[] DEFAULT NULL,
     exclude_tables text[] DEFAULT NULL,
-    function_schemas text[] DEFAULT NULL,
-    exclude_function_schemas text[] DEFAULT NULL,
+    exclude_table_schemas text[] DEFAULT NULL,
     functions text[] DEFAULT NULL,
     exclude_functions text[] DEFAULT NULL,
+    exclude_function_schemas text[] DEFAULT NULL,
     spatial boolean DEFAULT FALSE
 ) RETURNS SETOF jsonb AS $$
     WITH a AS (
@@ -217,7 +216,7 @@ CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
             AND c.relnamespace::regnamespace::text NOT IN ('pg_catalog', 'information_schema')
             AND c.relname::text NOT IN ('spatial_ref_sys','geometry_columns','geography_columns')
             AND (schemas IS NULL  OR c.relnamespace::regnamespace::text = ANY (schemas || pg_my_temp_schema()::regnamespace::text))
-            AND (exclude_schemas IS NULL OR c.relnamespace::regnamespace::text != ANY (exclude_schemas))
+            AND (exclude_table_schemas IS NULL OR c.relnamespace::regnamespace::text != ANY (exclude_table_schemas))
             AND (exclude_tables IS NULL OR concat(c.relnamespace::regnamespace::text,'.',c.relname::text) != ANY (exclude_tables))
             AND (tables IS NULL OR concat(c.relnamespace::regnamespace::text,'.',c.relname::text) = ANY (tables))
             AND (pg_table_is_visible(oid) or relnamespace=pg_my_temp_schema())
@@ -235,7 +234,7 @@ CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
             AND has_function_privilege(oid, 'execute')
             AND has_schema_privilege(pronamespace, 'usage')
             AND provariadic=0
-            AND (function_schemas IS NULL  OR p.pronamespace::regnamespace::text = ANY (function_schemas  || pg_my_temp_schema()::regnamespace::text))
+            AND (schemas IS NULL  OR p.pronamespace::regnamespace::text = ANY (schemas  || pg_my_temp_schema()::regnamespace::text))
             AND (functions IS NULL OR concat(p.pronamespace::regnamespace::text, '.', proname::text) = ANY (functions))
             AND (exclude_function_schemas IS NULL OR p.pronamespace::regnamespace::text != ANY (exclude_function_schemas))
             AND (exclude_functions IS NULL OR concat(p.pronamespace::regnamespace::text,'.',proname::text) != ANY (exclude_functions))

--- a/tipg/sql/dbcatalog.sql
+++ b/tipg/sql/dbcatalog.sql
@@ -128,7 +128,15 @@ CREATE OR REPLACE FUNCTION pg_temp.tipg_tproperties(
     SELECT pg_temp.tipg_tproperties(pg_class) FROM pg_class WHERE oid=tabl::regclass;
 $$ LANGUAGE SQL;
 
-
+CREATE OR REPLACE FUNCTION pg_temp.tipg_fun_defaults(defaults pg_node_tree) RETURNS text[] AS $$
+    WITH d AS (
+        SELECT btrim(split_part(btrim(string_to_table(
+                pg_get_expr(defaults,0::oid),
+                ','
+        )),'::',1),'''') d
+    ) SELECT array_agg(d) FROM d
+    ;
+$$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION pg_temp.tipg_fproperties(
     p pg_proc
@@ -144,7 +152,7 @@ BEGIN
     IF p.pronargdefaults > 0 AND p.pronargs > 0 THEN
         defaults :=
             array_fill(null::text, ARRAY[p.pronargs-p.pronargdefaults])
-            || string_to_array(pg_get_expr(p.proargdefaults, 0::OID),',')
+            || pg_temp.tipg_fun_defaults(p.proargdefaults)
         ;
     ELSE
         defaults := array_fill(null::text, ARRAY[p.pronargs]);
@@ -176,7 +184,7 @@ BEGIN
         jsonb_agg(json_strip_nulls(json_build_object(
             'name', proargname,
             'type', argtype,
-            'default', regexp_replace(def, '''([a-zA-Z0-9_\-\.]+)''::\w+', '\1', 'g')
+            'default', def
         )) ORDER BY argnum ) FILTER (WHERE argmode IN ('i','b'))
     FROM t INTO properties, parameters;
     RETURN jsonb_build_object(
@@ -195,6 +203,29 @@ CREATE OR REPLACE FUNCTION pg_temp.tipg_fproperties(
     SELECT pg_temp.tipg_fproperties(pg_proc) FROM pg_proc WHERE oid=func::regproc;
 $$ LANGUAGE SQL;
 
+CREATE OR REPLACE FUNCTION pg_temp.tipg_get_schemas(include text[] DEFAULT NULL, exclude text[] DEFAULT NULL) RETURNS SETOF oid AS $$
+DECLARE
+BEGIN
+    IF include IS NULL OR cardinality(include) = 0 THEN
+        include:=string_to_array(current_setting('search_path',false),',');
+    END IF;
+    RETURN QUERY
+        WITH schemas AS (
+            SELECT pg_my_temp_schema()::regnamespace::text AS _schema
+            UNION
+            SELECT btrim(unnest(include))
+            EXCEPT
+            SELECT btrim(unnest(exclude))
+        )
+        SELECT DISTINCT oid
+        FROM pg_namespace, schemas
+        WHERE
+            nspname::text=_schema
+            AND
+            has_schema_privilege(oid, 'usage')
+        ;
+END;
+$$ LANGUAGE PLPGSQL;
 
 CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
     schemas text[] DEFAULT NULL,
@@ -209,35 +240,31 @@ CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
     WITH a AS (
         SELECT
             pg_temp.tipg_tproperties(c) as meta
-        FROM pg_class c
+        FROM pg_class c, pg_temp.tipg_get_schemas(schemas,exclude_table_schemas) s
         WHERE
-            relkind IN ('r','v', 'm', 'f', 'p')
+            c.relnamespace=s
+            AND relkind IN ('r','v', 'm', 'f', 'p')
             AND has_table_privilege(c.oid, 'SELECT')
-            AND c.relnamespace::regnamespace::text NOT IN ('pg_catalog', 'information_schema')
             AND c.relname::text NOT IN ('spatial_ref_sys','geometry_columns','geography_columns')
-            AND (schemas IS NULL  OR c.relnamespace::regnamespace::text = ANY (schemas || pg_my_temp_schema()::regnamespace::text))
-            AND (exclude_table_schemas IS NULL OR c.relnamespace::regnamespace::text != ANY (exclude_table_schemas))
             AND (exclude_tables IS NULL OR concat(c.relnamespace::regnamespace::text,'.',c.relname::text) != ANY (exclude_tables))
             AND (tables IS NULL OR concat(c.relnamespace::regnamespace::text,'.',c.relname::text) = ANY (tables))
-            AND (pg_table_is_visible(oid) or relnamespace=pg_my_temp_schema())
+
         UNION ALL
         SELECT
             pg_temp.tipg_fproperties(p) as meta
         FROM
-            pg_proc p
+            pg_proc p, pg_temp.tipg_get_schemas(schemas,exclude_function_schemas) s
         WHERE
-            proretset
+            p.pronamespace=s
+            AND proretset
             AND prokind='f'
             AND proargnames is not null
             AND '' != ANY(proargnames)
-            AND (pg_function_is_visible(oid) OR pronamespace = pg_my_temp_schema())
             AND has_function_privilege(oid, 'execute')
-            AND has_schema_privilege(pronamespace, 'usage')
             AND provariadic=0
-            AND (schemas IS NULL  OR p.pronamespace::regnamespace::text = ANY (schemas  || pg_my_temp_schema()::regnamespace::text))
             AND (functions IS NULL OR concat(p.pronamespace::regnamespace::text, '.', proname::text) = ANY (functions))
-            AND (exclude_function_schemas IS NULL OR p.pronamespace::regnamespace::text != ANY (exclude_function_schemas))
             AND (exclude_functions IS NULL OR concat(p.pronamespace::regnamespace::text,'.',proname::text) != ANY (exclude_functions))
+            AND p.proname::text NOT ILIKE 'tipg_%'
     )
     SELECT meta FROM a
     WHERE

--- a/tipg/sql/dbcatalog.sql
+++ b/tipg/sql/dbcatalog.sql
@@ -197,11 +197,11 @@ $$ LANGUAGE SQL;
 
 
 CREATE OR REPLACE FUNCTION pg_temp.tipg_catalog(
-    schemas text[] DEFAULT '{public}',
+    schemas text[] DEFAULT NULL,
     exclude_schemas text[] DEFAULT NULL,
     tables text[] DEFAULT NULL,
     exclude_tables text[] DEFAULT NULL,
-    function_schemas text[] DEFAULT '{public}',
+    function_schemas text[] DEFAULT NULL,
     exclude_function_schemas text[] DEFAULT NULL,
     functions text[] DEFAULT NULL,
     exclude_functions text[] DEFAULT NULL,


### PR DESCRIPTION
closes #44 

~~This PR tries to implement a solution based on https://github.com/developmentseed/tipg/issues/44#issuecomment-1486973429 but local tests shows that it doesn't work~~

```
# Launch database
docker-compose up database -d 

# Create a copy of `public.countries` in `myschema.countries`
psql postgresql://username:password@0.0.0.0:5439/postgis -c "CREATE SCHEMA IF NOT EXISTS myschema; SET schema 'myschema'; DROP TABLE IF EXISTS myschema.countries CASCADE; CREATE TABLE myschema.countries AS SELECT * FROM public.countries; SELECT count(*) FROM myschema.countries;"

# Start TiPG service
DATABASE_URL=postgresql://username:password@0.0.0.0:5439/postgis TIPG_DB_SCHEMAS='["myschema"]'  uvicorn tipg.main:app --port 8000 --reload
```

~~when `function_schemas` is set to `[]` using `TIPG_DB_FUNCTION_SCHEMAS='[]' then it works.~~