### PR TITLE
add setting to set Limit value

### DIFF
--- a/docs/src/advanced/configuration.md
+++ b/docs/src/advanced/configuration.md
@@ -119,6 +119,19 @@ prefix: **`TIPG_`**
 TIPG_MAX_FEATURE_PER_TILE=1000
 ```
 
+## Features settings
+
+class: `tipg.settings.FeaturesSettings`
+
+prefix: **`TIPG_`**
+
+- **DEFAULT_FEATURES_LIMIT** (int): Set the default `Limit` values for `/items` endpoint. Default is `10`
+- **MAX_FEATURES_PER_QUERY** (int): Set the maximum number of features the `/items` endpoint can return. Default is `10000`.
+
+```bash
+TIPG_DEFAULT_FEATURES_LIMIT=1000 TIPG_MAX_FEATURES_PER_QUERY=2000
+```
+
 ## Tile Matrix Sets setting
 
 class: `tipg.settings.TMSSettings`

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -44,7 +44,7 @@ from tipg.dependencies import (
 from tipg.errors import MissingGeometryColumn, NoPrimaryKey, NotFound
 from tipg.resources.enums import MediaType
 from tipg.resources.response import GeoJSONResponse, SchemaJSONResponse
-from tipg.settings import TMSSettings
+from tipg.settings import FeaturesSettings, TMSSettings
 
 from fastapi import APIRouter, Depends, Path, Query
 from fastapi.responses import ORJSONResponse
@@ -55,6 +55,7 @@ from starlette.responses import HTMLResponse, Response, StreamingResponse
 from starlette.templating import Jinja2Templates, _TemplateResponse
 
 tms_settings = TMSSettings()
+features_settings = FeaturesSettings()
 
 DEFAULT_TEMPLATES = Jinja2Templates(
     directory="",
@@ -746,7 +747,9 @@ class OGCFeaturesFactory(EndpointsFactory):
                 alias="datetime-column",
             ),
             limit: int = Query(
-                10,
+                features_settings.default_features_limit,
+                ge=0,
+                lt=features_settings.max_features_per_query,
                 description="Limits the number of features in the response.",
             ),
             offset: Optional[int] = Query(

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -52,6 +52,29 @@ class TMSSettings(pydantic.BaseSettings):
         env_file = ".env"
 
 
+class FeaturesSettings(pydantic.BaseSettings):
+    """TiPG Items settings"""
+
+    default_features_limit: int = pydantic.Field(10, ge=0)
+    max_features_per_query: int = pydantic.Field(10000, ge=0)
+
+    class Config:
+        """model config"""
+
+        env_prefix = "TIPG_"
+        env_file = ".env"
+
+    @pydantic.root_validator(pre=False)
+    def max_default(cls, values):
+        """Set default bounds and srid when this is a function."""
+        if values.get("default_features_limit") > values.get("max_features_per_query"):
+            raise ValueError(
+                f"Invalid combination of `limit` ({values.get('default_features_limit')}) and `max features per query` ({values.get('max_features_per_query')}) values"
+            )
+
+        return values
+
+
 class MVTSettings(pydantic.BaseSettings):
     """TiPG MVT settings"""
 


### PR DESCRIPTION
closes #53 

This PR adds a new `Settings` with two variables:
- `default_features_limit`: Default LIMIT value (set to 10 by default)
- `max_features_per_query`: replace `max_features_per_tile` for `Collection.features` method
