### PR TITLE
update conformance links for those that exist

### DIFF
--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -265,13 +265,11 @@ class EndpointsFactory(metaclass=abc.ABCMeta):
             """Get conformance."""
             data = model.Conformance(
                 conformsTo=[
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landingPage",
-                    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/collections",
-                    "http://www.opengis.net/spec/ogcapi-common-2/1.0/conf/simple-query",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/landing-page",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/oas30",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/html",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/json"
                     *self.conforms_to,
                 ]
             )
@@ -358,8 +356,6 @@ class OGCFeaturesFactory(EndpointsFactory):
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/html",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
             "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter",
-            "http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/features-filter",
         ]
 
     def links(self, request: Request) -> List[model.Link]:

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -265,11 +265,11 @@ class EndpointsFactory(metaclass=abc.ABCMeta):
             """Get conformance."""
             data = model.Conformance(
                 conformsTo=[
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/core",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/landing-page",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/oas30",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/html",
-                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/req/json"
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/core",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/landing-page",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/json",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/html",
+                    "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/oas30",
                     *self.conforms_to,
                 ]
             )


### PR DESCRIPTION
## What I am changing

Fixing/removing conformance links that are 404'ing

## How I did it

I didn't immediately notice but the newest OGC docs (see links below) have removed the bad links, so I followed that example (outside of the ogcapi-features-3.0 examples which are broken and not removed).

https://docs.ogc.org/is/19-072/19-072.html#toc64
https://docs.opengeospatial.org/is/17-069r4/17-069r4.html#_response_3

I also left some questions on the relevant ogcapi repos:

https://github.com/opengeospatial/ogcapi-features/issues/821
https://github.com/opengeospatial/ogcapi-common/issues/327

## How you can test it

```bash
for link in links:
    curl -XGET link
```
