### PR TITLE
Add TTL for refreshing catalog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - POSTGRES_DB=postgis
     ports:
       - "5439:5432"
-    command: postgres -N 500
+    command: postgres -N 500 -c log_statement=all -c log_destination=stderr
     volumes:
       - ./.pgdata:/var/lib/postgresql/data
 
@@ -90,4 +90,3 @@ services:
   #     serve --dbconn postgresql://username:password@database:5432/postgis --bind=0.0.0.0 --port 3000
   #   depends_on:
   #     - database
-

--- a/tipg/logger.py
+++ b/tipg/logger.py
@@ -2,4 +2,5 @@
 
 import logging
 
-logger = logging.getLogger("tipg")
+logger = logging.getLogger("uvicorn")
+logger.setLevel(logging.DEBUG)

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -8,6 +8,7 @@ from tipg import __version__ as tipg_version
 from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
 from tipg.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from tipg.factory import Endpoints
+from tipg.logger import logger
 from tipg.middleware import CacheControlMiddleware
 from tipg.settings import (
     APISettings,
@@ -74,6 +75,8 @@ add_exception_handlers(app, DEFAULT_STATUS_CODES)
 @app.on_event("startup")
 async def startup_event() -> None:
     """Connect to database on startup."""
+    logger.debug("In Startup Event.")
+    app.state.db_settings = db_settings
     await connect_to_db(
         app,
         settings=postgres_settings,
@@ -82,14 +85,6 @@ async def startup_event() -> None:
     )
     await register_collection_catalog(
         app,
-        schemas=db_settings.schemas,
-        tables=db_settings.tables,
-        exclude_tables=db_settings.exclude_tables,
-        exclude_table_schemas=db_settings.exclude_table_schemas,
-        functions=db_settings.functions,
-        exclude_functions=db_settings.exclude_functions,
-        exclude_function_schemas=db_settings.exclude_function_schemas,
-        spatial=db_settings.only_spatial_tables,
     )
 
 

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -2,6 +2,7 @@
 
 import pathlib
 import sys
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import pydantic
@@ -174,6 +175,8 @@ class DatabaseSettings(pydantic.BaseSettings):
     exclude_function_schemas: Optional[List[str]]
 
     only_spatial_tables: bool = True
+
+    catalog_ttl: timedelta = timedelta(hours=1)
 
     class Config:
         """model config"""


### PR DESCRIPTION
Start of work to add a TTL setting to force refetching the catalog for each collection when the entry for that collection is older than the TTL. When starting up, it always grabs all collections. When hitting the /collections endpoint, it will check each collection and only fetch ones older than the TTL. When hitting any /collections/{collection}/... endpoint, it will check that collection and only request that collection if older than the TTL.

TODO:

- [ ] Add parameter to force refetching.
- [ ] Tests