### PR TITLE
Refactor #68: Database Catalog TTL

### DIFF
--- a/tests/routes/test_collections.py
+++ b/tests/routes/test_collections.py
@@ -9,7 +9,13 @@ def test_collections(app):
     assert response.status_code == 200
     assert response.headers["content-type"] == "application/json"
     body = response.json()
-    assert ["links", "numberMatched", "numberReturned", "collections"] == list(body)
+    assert [
+        "links",
+        "numberMatched",
+        "numberReturned",
+        "collections",
+        "lastUpdated",
+    ] == list(body)
     assert body["numberMatched"] == collection_number
     assert body["numberReturned"] == collection_number
 

--- a/tests/routes/test_collections.py
+++ b/tests/routes/test_collections.py
@@ -14,7 +14,6 @@ def test_collections(app):
         "numberMatched",
         "numberReturned",
         "collections",
-        "lastUpdated",
     ] == list(body)
     assert body["numberMatched"] == collection_number
     assert body["numberReturned"] == collection_number

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,3 +6,9 @@ def test_health(app):
     response = app.get("/healthz")
     assert response.status_code == 200
     assert response.json() == {"ping": "pong!"}
+
+    response = app.get("/rawcatalog")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["collections"]
+    assert body["last_updated"]

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,27 @@
+"""Test tipg middleware."""
+
+import time
+
+
+def test_middleware(app_middleware_refresh):
+    """Test CatalogUpdateMiddleware."""
+    # Wait we pass the `ttl`
+    time.sleep(2)
+
+    response = app_middleware_refresh.get("/rawcatalog")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["collections"]
+    last_updated = body["last_updated"]
+
+    # Because we waited 2 seconds before the request
+    # the background task should have been called
+    # let's wait until the refresh is done
+    time.sleep(5)
+
+    response = app_middleware_refresh.get("/rawcatalog")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["collections"]
+    new_updated = body["last_updated"]
+    assert last_updated != new_updated

--- a/tipg/db.py
+++ b/tipg/db.py
@@ -1,7 +1,6 @@
 """tipg.db: database events."""
 
 import pathlib
-from datetime import datetime
 from typing import Any, List, Optional
 
 import orjson
@@ -95,7 +94,6 @@ async def connect_to_db(
 
 async def register_collection_catalog(app: FastAPI, **kwargs: Any) -> None:
     """Register Table catalog."""
-    app.state.catalog_expire = datetime.now() + app.state.db_settings.catalog_ttl
     app.state.collection_catalog = await get_collection_index(app.state.pool, **kwargs)
 
 

--- a/tipg/dbmodel.py
+++ b/tipg/dbmodel.py
@@ -1,5 +1,6 @@
 """tipg.dbmodel: database events."""
 
+import datetime
 import re
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
@@ -873,7 +874,11 @@ class Collection(BaseModel):
         return {**geoms, **props}
 
 
-Database = Dict[str, Collection]
+class Database(TypedDict):
+    """Database."""
+
+    collections: Dict[str, Collection]
+    last_updated: datetime.datetime
 
 
 async def get_collection_index(  # noqa: C901
@@ -916,7 +921,7 @@ async def get_collection_index(  # noqa: C901
             spatial=spatial,
         )
 
-        catalog = {}
+        catalog: Dict[str, Collection] = {}
         table_settings = TableSettings()
         table_confs = table_settings.table_config
         fallback_key_names = table_settings.fallback_key_names
@@ -976,4 +981,4 @@ async def get_collection_index(  # noqa: C901
                 parameters=table.get("parameters", []),
             )
 
-        return catalog
+        return Database(collections=catalog, last_updated=datetime.datetime.now())

--- a/tipg/dependencies.py
+++ b/tipg/dependencies.py
@@ -9,7 +9,7 @@ from pygeofilter.ast import AstType
 from pygeofilter.parsers.cql2_json import parse as cql2_json_parser
 from pygeofilter.parsers.cql2_text import parse as cql2_text_parser
 
-from tipg.dbmodel import Collection
+from tipg.dbmodel import Collection, Database
 from tipg.errors import InvalidBBox, MissingFunctionParameter
 from tipg.resources import enums
 from tipg.settings import TMSSettings
@@ -37,9 +37,12 @@ def CollectionParams(
     assert collection_pattern.groupdict()["schema"]
     assert collection_pattern.groupdict()["collection"]
 
-    collection_catalog = getattr(request.app.state, "collection_catalog", {})
-    if collectionId in collection_catalog:
-        return collection_catalog[collectionId]
+    collection_catalog: Database = request.app.state.collection_catalog
+    if not collection_catalog:
+        raise HTTPException(status_code=500, detail="Could not find collections.")
+
+    if collectionId in collection_catalog["collections"]:
+        return collection_catalog["collections"][collectionId]
 
     raise HTTPException(
         status_code=404, detail=f"Table/Function '{collectionId}' not found."

--- a/tipg/dependencies.py
+++ b/tipg/dependencies.py
@@ -10,7 +10,7 @@ from pygeofilter.parsers.cql2_json import parse as cql2_json_parser
 from pygeofilter.parsers.cql2_text import parse as cql2_text_parser
 
 from tipg.dbmodel import Collection, Database
-from tipg.errors import InvalidBBox, MissingFunctionParameter
+from tipg.errors import InvalidBBox, MissingCollectionCatalog, MissingFunctionParameter
 from tipg.resources import enums
 from tipg.settings import TMSSettings
 
@@ -37,9 +37,11 @@ def CollectionParams(
     assert collection_pattern.groupdict()["schema"]
     assert collection_pattern.groupdict()["collection"]
 
-    collection_catalog: Database = request.app.state.collection_catalog
+    collection_catalog: Database = getattr(
+        request.app.state, "collection_catalog", None
+    )
     if not collection_catalog:
-        raise HTTPException(status_code=500, detail="Could not find collections.")
+        raise MissingCollectionCatalog("Could not find collections catalog.")
 
     if collectionId in collection_catalog["collections"]:
         return collection_catalog["collections"][collectionId]

--- a/tipg/errors.py
+++ b/tipg/errors.py
@@ -66,6 +66,10 @@ class FunctionDirectoryDoesNotExist(TiPgError):
     """Function Directory Is Set But Does Not Exist."""
 
 
+class MissingCollectionCatalog(TiPgError):
+    """`collection_catalog` not registered in the application state."""
+
+
 DEFAULT_STATUS_CODES = {
     NotFound: status.HTTP_404_NOT_FOUND,
     InvalidBBox: status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -81,6 +85,7 @@ DEFAULT_STATUS_CODES = {
     NoPrimaryKey: status.HTTP_422_UNPROCESSABLE_ENTITY,
     MissingFunctionParameter: status.HTTP_422_UNPROCESSABLE_ENTITY,
     FunctionDirectoryDoesNotExist: status.HTTP_500_INTERNAL_SERVER_ERROR,
+    MissingCollectionCatalog: status.HTTP_500_INTERNAL_SERVER_ERROR,
 }
 
 

--- a/tipg/logger.py
+++ b/tipg/logger.py
@@ -2,5 +2,4 @@
 
 import logging
 
-logger = logging.getLogger("uvicorn")
-logger.setLevel(logging.DEBUG)
+logger = logging.getLogger("tipg")

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -69,7 +69,10 @@ if settings.cors_origins:
 
 app.add_middleware(CacheControlMiddleware, cachecontrol=settings.cachecontrol)
 app.add_middleware(CompressionMiddleware)
-app.add_middleware(CatalogUpdateMiddleware, ttl=settings.catalog_ttl)
+
+if settings.catalog_ttl:
+    app.add_middleware(CatalogUpdateMiddleware, ttl=settings.catalog_ttl)
+
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 
 

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -69,7 +69,7 @@ if settings.cors_origins:
 
 app.add_middleware(CacheControlMiddleware, cachecontrol=settings.cachecontrol)
 app.add_middleware(CompressionMiddleware)
-app.add_middleware(CatalogUpdateMiddleware)
+app.add_middleware(CatalogUpdateMiddleware, ttl=settings.catalog_ttl)
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 
 

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -71,7 +71,18 @@ app.add_middleware(CacheControlMiddleware, cachecontrol=settings.cachecontrol)
 app.add_middleware(CompressionMiddleware)
 
 if settings.catalog_ttl:
-    app.add_middleware(CatalogUpdateMiddleware, ttl=settings.catalog_ttl)
+    app.add_middleware(
+        CatalogUpdateMiddleware,
+        ttl=settings.catalog_ttl,
+        schemas=db_settings.schemas,
+        tables=db_settings.tables,
+        exclude_tables=db_settings.exclude_tables,
+        exclude_table_schemas=db_settings.exclude_table_schemas,
+        functions=db_settings.functions,
+        exclude_functions=db_settings.exclude_functions,
+        exclude_function_schemas=db_settings.exclude_function_schemas,
+        spatial=db_settings.only_spatial_tables,
+    )
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
 

--- a/tipg/middleware.py
+++ b/tipg/middleware.py
@@ -2,7 +2,7 @@
 
 import re
 from datetime import datetime, timedelta
-from typing import Optional, Set
+from typing import Any, Optional, Set
 
 from tipg.db import register_collection_catalog
 from tipg.logger import logger
@@ -55,21 +55,23 @@ class CatalogUpdateMiddleware(BaseHTTPMiddleware):
         self,
         app: ASGIApp,
         ttl: int = 300,
+        **kwargs: Any,
     ) -> None:
         """Init Middleware.
 
         Args:
             app (ASGIApp): starlette/FastAPI application.
             ttl (int): time-to-live value in seconds. Defaults to 300.
+            kwargs (any): additional argument to pass to the `register_collection_catalog` method
 
         """
         super().__init__(app)
         self.ttl = ttl
+        self.kwargs = kwargs
 
     async def dispatch(self, request: Request, call_next):
         """Fetch Catalog either immediately or in background."""
         response = await call_next(request)
-
         collection_catalog = getattr(request.app.state, "collection_catalog", {})
         last_updated = collection_catalog.get("last_updated")
         if not last_updated or datetime.now() > (
@@ -79,7 +81,9 @@ class CatalogUpdateMiddleware(BaseHTTPMiddleware):
                 f"Running catalog refresh in background. Last Updated: {last_updated}"
             )
             response.background = BackgroundTask(
-                register_collection_catalog, request.app
+                register_collection_catalog,
+                request.app,
+                **self.kwargs,
             )
 
         return response

--- a/tipg/model.py
+++ b/tipg/model.py
@@ -110,6 +110,11 @@ class Collections(BaseModel):
     numberReturned: Optional[int]
     collections: List[Collection]
 
+    class Config:
+        """Collection model configuration."""
+
+        extra = "allow"
+
 
 class Item(Feature):
     """Item model

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -2,7 +2,6 @@
 
 import pathlib
 import sys
-from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
 import pydantic
@@ -104,6 +103,8 @@ class APISettings(pydantic.BaseSettings):
 
     add_tiles_viewer: bool = True
 
+    catalog_ttl: int = 300
+
     @pydantic.validator("cors_origins")
     def parse_cors_origin(cls, v):
         """Parse CORS origins."""
@@ -175,8 +176,6 @@ class DatabaseSettings(pydantic.BaseSettings):
     exclude_function_schemas: Optional[List[str]]
 
     only_spatial_tables: bool = True
-
-    catalog_ttl: timedelta = timedelta(minutes=5)
 
     class Config:
         """model config"""


### PR DESCRIPTION
This PR updates #68:

- move settings to the API settings 
- move state variable to the `Database` object (`last_updated`) 
- ~~add `lastUpdated` in the `/collections` response (NOT IN THE SPECIFICATION)~~
- remove the `refresh` catch in the middleware 