### PR TITLE
refactor submodule names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,37 @@
 # Release Notes
 
-## Next (TBD)
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/).
+
+Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
+
+## [unreleased] - TBD
 
 * remove useless `app.state.db_settings`
 
-## 0.1.0 (2023-06-15)
+**breaking changes**
+
+* rename `tipg.db` -> `tipg.database`
+* rename `tipg.dbmodel` -> `tipg.collections`
+* rename `tipg.dbmodel.Database` -> `tipg.collections.Catalog`
+* move `register_collection_catalog` from `tipg.dbmodel` to `tipg.collections`
+
+    ```python
+    # before
+    from tipg.db import close_db_connection, connect_to_db
+    from tipg.db import register_collection_catalog
+    from tipg.dbmodel import Database, Collection
+
+    # now
+    from tipg.collections import Catalog, Collection
+    from tipg.collections import register_collection_catalog
+    from tipg.database import close_db_connection, connect_to_db
+    ```
+
+## [0.1.0] - 2023-06-15
 
 * Initial release
+
+[unreleased]: https://github.com/developmentseed/tipg/compare/0.1.0...HEAD
+[0.1.0]: https://github.com/developmentseed/tipg/compare/9ca80c0bd57d8ce57e37c1709e26d1af1559bc1e...0.1.0

--- a/docs/src/advanced/customization.md
+++ b/docs/src/advanced/customization.md
@@ -8,7 +8,8 @@ While `Tipg` provides a default application `tipg.main:app`, users can easily cr
 
 ```python
 from contextlib import asynccontextmanager
-from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
+from tipg.database import close_db_connection, connect_to_db
+from tipg.collections import register_collection_catalog
 from tipg.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from tipg.factory import OGCFeaturesFactory
 from tipg.settings import DatabaseSettings
@@ -95,7 +96,8 @@ In [`eoAPI`](https://github.com/developmentseed/eoAPI), we use a custom logo by 
 To `register` custom SQL functions, user can set `TIPG_CUSTOM_SQL_DIRECTORY` environment variable when using `tipg` demo application or set `user_sql_files` option in [tipg.db.connect_to_db](https://github.com/developmentseed/tipg/blob/2543707238a97a0527effff710a83f9bea66440f/tipg/main.py#L90-L109).
 
 ```python
-from tipg.db import connect_to_db, register_collection_catalog
+from tipg.database import connect_to_db
+from tipg.collections import register_collection_catalog
 from tipg.settings import PostgresSettings
 
 postgres_settings = PostgresSettings()

--- a/docs/src/user_guide/factories.md
+++ b/docs/src/user_guide/factories.md
@@ -61,7 +61,7 @@ app.include_router(endpoints.router, tags=["OGC Features API"])
 
 #### Creation Options
 
-- **collection_dependency** (Callable[..., tipg.dbmodel.Collection]): Callable which return a Collection instance
+- **collection_dependency** (Callable[..., tipg.collections.Collection]): Callable which return a Collection instance
 
 - **with_common** (bool, optional): Create Full OGC Features API set of endpoints with OGC Common endpoints (landing `/` and conformance `/conformance`). Defaults to `True`
 
@@ -98,7 +98,7 @@ app.include_router(endpoints.router, tags=["OGC Tiles API"])
 
 #### Creation Options
 
-- **collection_dependency** (Callable[..., tipg.dbmodel.Collection]): Callable which return a Collection instance
+- **collection_dependency** (Callable[..., tipg.collections.Collection]): Callable which return a Collection instance
 
 - **supported_tms** (morecantile.TileMatrixSets): morecantile TileMatrixSets instance (holds a set of TileMatrixSet documents)
 
@@ -141,7 +141,7 @@ app.include_router(endpoints.router)
 
 #### Creation Options
 
-- **collection_dependency** (Callable[..., tipg.dbmodel.Collection]): Callable which return a Collection instance
+- **collection_dependency** (Callable[..., tipg.collections.Collection]): Callable which return a Collection instance
 
 - **supported_tms** (morecantile.TileMatrixSets): morecantile TileMatrixSets instance (holds a set of TileMatrixSet documents)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,8 @@ def create_tipg_app(
 ) -> FastAPI:
     """Create TiPG Application."""
 
-    from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
+    from tipg.collections import register_collection_catalog
+    from tipg.database import close_db_connection, connect_to_db
     from tipg.factory import Endpoints
 
     @asynccontextmanager
@@ -337,7 +338,8 @@ def app_myschema_public_order(database_url, monkeypatch):
 def app_middleware_refresh(database_url, monkeypatch):
     """Create APP with CatalogUpdateMiddleware middleware."""
 
-    from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
+    from tipg.collections import register_collection_catalog
+    from tipg.database import close_db_connection, connect_to_db
     from tipg.middleware import CatalogUpdateMiddleware
 
     postgres_settings = PostgresSettings(database_url=database_url)

--- a/tests/routes/test_tiles.py
+++ b/tests/routes/test_tiles.py
@@ -3,7 +3,7 @@
 import mapbox_vector_tile
 import numpy as np
 
-from tipg.dbmodel import mvt_settings
+from tipg.collections import mvt_settings
 
 
 def test_tilejson(app):

--- a/tipg/database.py
+++ b/tipg/database.py
@@ -1,12 +1,11 @@
 """tipg.db: database events."""
 
 import pathlib
-from typing import Any, List, Optional
+from typing import List, Optional
 
 import orjson
 from buildpg import asyncpg
 
-from tipg.dbmodel import get_collection_index
 from tipg.logger import logger
 from tipg.settings import PostgresSettings
 
@@ -90,11 +89,6 @@ async def connect_to_db(
         init=con_init,
         **kwargs,
     )
-
-
-async def register_collection_catalog(app: FastAPI, **kwargs: Any) -> None:
-    """Register Table catalog."""
-    app.state.collection_catalog = await get_collection_index(app.state.pool, **kwargs)
 
 
 async def close_db_connection(app: FastAPI) -> None:

--- a/tipg/dependencies.py
+++ b/tipg/dependencies.py
@@ -10,7 +10,7 @@ from pygeofilter.ast import AstType
 from pygeofilter.parsers.cql2_json import parse as cql2_json_parser
 from pygeofilter.parsers.cql2_text import parse as cql2_text_parser
 
-from tipg.dbmodel import Collection, Database
+from tipg.collections import Catalog, Collection
 from tipg.errors import InvalidBBox, MissingCollectionCatalog, MissingFunctionParameter
 from tipg.resources import enums
 from tipg.settings import TMSSettings
@@ -44,9 +44,7 @@ def CollectionParams(
     assert collection_pattern.groupdict()["schema"]
     assert collection_pattern.groupdict()["collection"]
 
-    collection_catalog: Database = getattr(
-        request.app.state, "collection_catalog", None
-    )
+    collection_catalog: Catalog = getattr(request.app.state, "collection_catalog", None)
     if not collection_catalog:
         raise MissingCollectionCatalog("Could not find collections catalog.")
 

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -27,7 +27,7 @@ from morecantile.defaults import TileMatrixSets
 from pygeofilter.ast import AstType
 
 from tipg import model
-from tipg.dbmodel import Collection, Database
+from tipg.collections import Catalog, Collection
 from tipg.dependencies import (
     CollectionParams,
     ItemsOutputType,
@@ -461,7 +461,7 @@ class OGCFeaturesFactory(EndpointsFactory):
             output_type: Annotated[Optional[MediaType], Depends(OutputType)] = None,
         ):
             """List of collections."""
-            collection_catalog: Database = getattr(
+            collection_catalog: Catalog = getattr(
                 request.app.state, "collection_catalog", None
             )
             if not collection_catalog:

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -6,7 +6,8 @@ from typing import Any, List
 import jinja2
 
 from tipg import __version__ as tipg_version
-from tipg.db import close_db_connection, connect_to_db, register_collection_catalog
+from tipg.collections import register_collection_catalog
+from tipg.database import close_db_connection, connect_to_db
 from tipg.errors import DEFAULT_STATUS_CODES, add_exception_handlers
 from tipg.factory import Endpoints
 from tipg.middleware import CacheControlMiddleware, CatalogUpdateMiddleware

--- a/tipg/middleware.py
+++ b/tipg/middleware.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Optional, Set
 
-from tipg.db import register_collection_catalog
+from tipg.collections import register_collection_catalog
 from tipg.logger import logger
 
 from starlette.background import BackgroundTask


### PR DESCRIPTION
This PR does:
- rename `tipg.db` -> `tipg.database`
- rename `tipg.dbmodel` -> `tipg.collections` 
- move `register_collection_catalog` in `tipg.collections`
- rename `tipg.collections.Database` -> `tipg.collections.Catalog` 