### PR TITLE
Add writing setting

### DIFF
--- a/tipg/database.py
+++ b/tipg/database.py
@@ -7,7 +7,7 @@ import orjson
 from buildpg import asyncpg
 
 from tipg.logger import logger
-from tipg.settings import PostgresSettings, DatabaseSettings
+from tipg.settings import DatabaseSettings, PostgresSettings
 
 from fastapi import FastAPI
 
@@ -20,6 +20,7 @@ except ImportError:
 DB_CATALOG_FILE = resources_files(__package__) / "sql" / "dbcatalog.sql"
 
 database_settings = DatabaseSettings()
+
 
 class connection_factory:
     """Connection creation."""

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -177,6 +177,8 @@ class DatabaseSettings(pydantic.BaseSettings):
 
     only_spatial_tables: bool = True
 
+    write_functions: bool = True
+
     class Config:
         """model config"""
 


### PR DESCRIPTION
## What I am changing

In our usage of tipg (lambdas and Aurora on AWS) we're connecting to a database endpoint which is read-only, so I've added a setting for disabling the writing of the functions and the custom SQL to the database.

I haven't added docs yet, but at this stage I wanted to check in if you're interested in merging this and if so if the setting is in the right category or if there would be a better category (e.g. PostgresSettings)