### PR TITLE
Small fix to transform to 4326

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,36 +10,37 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ### Added
 
-* `type` query parameter to filter collections based on their type (`Function` or `Table`)
+- `type` query parameter to filter collections based on their type (`Function` or `Table`)
+- fixed a small bug in the `tipg_properties` SQL function where the bounds property was not properly transformed to 4326
 
 ## [0.2.0] - 2023-06-22
 
 ### Changed
 
-* rename `tipg.db` -> `tipg.database`
-* rename `tipg.dbmodel` -> `tipg.collections`
-* rename `tipg.dbmodel.Database` -> `tipg.collections.Catalog`
-* move `register_collection_catalog` from `tipg.dbmodel` to `tipg.collections`
+- rename `tipg.db` -> `tipg.database`
+- rename `tipg.dbmodel` -> `tipg.collections`
+- rename `tipg.dbmodel.Database` -> `tipg.collections.Catalog`
+- move `register_collection_catalog` from `tipg.dbmodel` to `tipg.collections`
 
-    ```python
-    # before
-    from tipg.db import close_db_connection, connect_to_db
-    from tipg.db import register_collection_catalog
-    from tipg.dbmodel import Database, Collection
+  ```python
+  # before
+  from tipg.db import close_db_connection, connect_to_db
+  from tipg.db import register_collection_catalog
+  from tipg.dbmodel import Database, Collection
 
-    # now
-    from tipg.collections import Catalog, Collection
-    from tipg.collections import register_collection_catalog
-    from tipg.database import close_db_connection, connect_to_db
-    ```
+  # now
+  from tipg.collections import Catalog, Collection
+  from tipg.collections import register_collection_catalog
+  from tipg.database import close_db_connection, connect_to_db
+  ```
 
 ### Removed
 
-* remove useless `app.state.db_settings`
+- remove useless `app.state.db_settings`
 
 ## [0.1.0] - 2023-06-15
 
-* Initial release
+- Initial release
 
 [unreleased]: https://github.com/developmentseed/tipg/compare/0.2.0...HEAD
 [0.2.0]: https://github.com/developmentseed/tipg/compare/0.1.0...0.2.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 ### Added
 
 - `type` query parameter to filter collections based on their type (`Function` or `Table`)
-- fixed a small bug in the `tipg_properties` SQL function where the bounds property was not properly transformed to 4326
+- fixed a small bug in the `tipg_properties` SQL function where the bounds property was not properly transformed to 4326  (author @RemcoMeeuwissen, https://github.com/developmentseed/tipg/pull/87)
 
 ## [0.2.0] - 2023-06-22
 

--- a/tests/routes/test_tiles.py
+++ b/tests/routes/test_tiles.py
@@ -58,6 +58,17 @@ def test_tilejson(app):
     assert resp_json["maxzoom"] == 2
     assert "?limit=1000" in resp_json["tiles"][0]
 
+    # Make sure that a non-4326 collection still returns the bounds in 4326
+    response = app.get("/collections/public.minnesota/tilejson.json")
+    assert response.status_code == 200
+
+    resp_json = response.json()
+
+    np.testing.assert_almost_equal(
+        resp_json["bounds"],
+        [-96.28961808496446, 46.11168980088226, -93.05330550250615, 48.56828559755232],
+    )
+
 
 def test_tile(app):
     """request a tile."""

--- a/tipg/sql/dbcatalog.sql
+++ b/tipg/sql/dbcatalog.sql
@@ -81,7 +81,7 @@ BEGIN
 
         IF bounds_geom IS NOT NULL THEN
             IF srid != 4326 THEN
-                bounds_geom := st_transform(bounds_geom, srid);
+                bounds_geom := st_transform(bounds_geom, 4326);
             END IF;
             bounds = ARRAY[ st_xmin(bounds_geom), st_ymin(bounds_geom), st_xmax(bounds_geom), st_ymax(bounds_geom) ];
         END IF;


### PR DESCRIPTION
## What I am changing

We found a small bug where, if the geom is not 4326 it should transform to 4326 but instead the transform uses the SRID which the geom is already in.

Should [line 97](https://github.com/RemcoMeeuwissen/tipg/blob/main/tipg/sql/dbcatalog.sql#L97) also be changed? Because it's also going to use the geom native SRID rather than 4326.
