### PR TITLE
generate popup contents without string concat.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 ### Added
 
 - `type` query parameter to filter collections based on their type (`Function` or `Table`)
-- fixed a small bug in the `tipg_properties` SQL function where the bounds property was not properly transformed to 4326  (author @RemcoMeeuwissen, https://github.com/developmentseed/tipg/pull/87)
-- added popups to leaflet maps on `items` and `item` page. (author @krishnaglodha, https://github.com/developmentseed/tipg/pull/91)
+- fixed a small bug in the `tipg_properties` SQL function where the bounds property was not properly transformed to 4326 (author @RemcoMeeuwissen, https://github.com/developmentseed/tipg/pull/87)
+- added popups to leaflet maps on `items` and `item` page. (author @krishnaglodha & @jackharrhy, https://github.com/developmentseed/tipg/pull/91, https://github.com/developmentseed/tipg/pull/94)
 
 ## [0.2.0] - 2023-06-22
 

--- a/tipg/templates/item.html
+++ b/tipg/templates/item.html
@@ -39,22 +39,51 @@
       attribution: 'Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }
   ));
+
+  function displayValue(value) {
+    switch (typeof value) {
+      case 'string':
+        return value;
+      case 'number':
+        return value.toString();
+      case 'object':
+        if (value instanceof Array) {
+          return value.map(displayValue).join(', ');
+        } else {
+          return JSON.stringify(value);
+        }
+      default:
+        return '';
+    }
+  }
+
   function addPopup(feature, layer) {
     if (feature.properties) {
-          //popup HTML
-  var HTMLContent = '<div style="overflow-x:scroll">'
-  Object.keys(geojson.properties).map(prop => {
-    HTMLContent += `<b>${prop}</b> : ${geojson.properties[prop]} <br>`
+      var popupElm = document.createElement('div');
+      popupElm.style.overflowX = 'scroll';
 
-  })
-  HTMLContent += `</div>`
-    
-        layer.bindPopup(HTMLContent);
+      Object.keys(geojson.properties).map(prop => {
+        var propElm = document.createElement('div');
+
+        var bElm = document.createElement('b');
+        bElm.innerText = prop;
+        propElm.appendChild(bElm);
+        var valueElm = document.createTextNode(` : ${displayValue(feature.properties[prop])}`);
+        propElm.appendChild(valueElm);
+
+        var brElm = document.createElement('br');
+        propElm.appendChild(brElm);
+
+        popupElm.appendChild(propElm);
+      })
+
+      layer.bindPopup(popupElm);
     }
-}
+  }
+
   var features = L.geoJSON(geojson, {
     onEachFeature: addPopup
-}).addTo(map);
+  }).addTo(map);
   
   map.fitBounds(features.getBounds());
 </script>

--- a/tipg/templates/items.html
+++ b/tipg/templates/items.html
@@ -96,13 +96,19 @@ $(function() {
       attribution: 'Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
     }
   ));
+
   function addPopup(feature, layer) {
-   HTMLContent = `<a target="_blank" href="${currentURL}/${feature.id}">${feature.id}</a>`
-   layer.bindPopup(HTMLContent);
-}
+    var aElm = document.createElement('a');
+    aElm.setAttribute('href', `${currentURL}/${feature.id}`);
+    aElm.setAttribute('target', '_blank');
+    aElm.innerText = feature.id;
+    layer.bindPopup(aElm);
+  }
+
   var features = L.geoJSON(geojson, {
     onEachFeature: addPopup
-}).addTo(map);
+  }).addTo(map);
+
   map.fitBounds(features.getBounds());
 
   //


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Previous version of popup content generation is vulnerable to [XSS attacks](https://owasp.org/www-community/attacks/xss/) due to crafting raw HTML from feature properties.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Instead of generating the popup contents from string concatenation, generate from using document.`...` APIs instead
- This method of creating content, while more verbose, should not be vulnerable to XSS due to any feature content being added as innerText

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
Insert this table into the db:

```sql
CREATE TABLE xss (name varchar primary key, geom geometry, description varchar);
INSERT INTO xss VALUES ('XSS Test', 'POINT(0 0)', '<p onclick="alert(1)">click me!</p>');
```

Navigate to http://localhost:8000/collections/public.xss/items/XSS%20Test

On current main: notice that clicking on the popup, and then clicking on the text, will popup with an alert:

![image](https://github.com/developmentseed/tipg/assets/6486417/89b6c0cc-921c-4b1b-a7cd-fd54b12605be)

On this branch, the popup will render the true contents, and is not clickable as before:

![image](https://github.com/developmentseed/tipg/assets/6486417/202dbc55-293f-4624-9edc-44f6ce6b5c26)


