### PR TITLE
fix function based collections without params

### DIFF
--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -970,6 +970,9 @@ async def get_collection_index(  # noqa: C901
                     ):
                         geometry_column = c
 
+            if table.get("parameters") is None:
+                table["parameters"] = []
+
             catalog[table_id] = Collection(
                 type=table["entity"],
                 id=table_id,
@@ -980,7 +983,7 @@ async def get_collection_index(  # noqa: C901
                 properties=properties,
                 datetime_column=datetime_column,
                 geometry_column=geometry_column,
-                parameters=table.get("parameters", []),
+                parameters=table["parameters"],
             )
 
         return Catalog(collections=catalog, last_updated=datetime.datetime.now())


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- Currently, parameter-less functions are broken on startup when the Collection model is instantiated by them

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Handle the table dict having an explicit `parameters: None` properly, always default to a list to make pydantic happy

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
Create the following function
```sql
CREATE OR REPLACE FUNCTION public.test() RETURNS TABLE(foo integer, location geometry)
AS 'SELECT 1, ST_MakePoint(0,0);' LANGUAGE SQL;
```

### Currently

Launching tipg will fail when it goes to create an instance of Collection based off of this function due to a validation error

### After this PR

Launching tipg will work as expected without any validation errors
