### PR TITLE
fix custom sql dir not optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
 
+## [unreleased]
+
+### Fixed
+
+- set `custom_sql_directory` in `CustomSQLSettings` to `None` to ensure it can be properly optional
+
 ## [0.4.0] - 2023-08-01
 
 ### Changed

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -165,7 +165,7 @@ class DatabaseSettings(BaseSettings):
 class CustomSQLSettings(BaseSettings):
     """TiPg Custom SQL settings."""
 
-    custom_sql_directory: Optional[DirectoryPath]
+    custom_sql_directory: Optional[DirectoryPath] = None
 
     model_config = {"env_prefix": "TIPG_", "env_file": ".env", "extra": "ignore"}
 


### PR DESCRIPTION
- set custom_sql_directory to default to None
- updated changelog

---

Without this, if no `custom_sql_directory` is specified, starting the default tipg.main:app will fail with a pydantic error
