### PR TITLE
use older function to support old Postgres

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
 
+## [0.4.4] - TBD
+
+### fixed
+
+- replace `string_to_table(...)` by `unnest(string_to_array(...))` to support Postgres<14
+
 ## [0.4.3] - 2023-08-28
 
 ### fixed
@@ -131,7 +137,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 - Initial release
 
-[unreleased]: https://github.com/developmentseed/tipg/compare/0.4.3...HEAD
+[unreleased]: https://github.com/developmentseed/tipg/compare/0.4.4...HEAD
+[0.4.4]: https://github.com/developmentseed/tipg/compare/0.4.3...0.4.4
 [0.4.3]: https://github.com/developmentseed/tipg/compare/0.4.2...0.4.3
 [0.4.2]: https://github.com/developmentseed/tipg/compare/0.4.1...0.4.2
 [0.4.1]: https://github.com/developmentseed/tipg/compare/0.4.0...0.4.1

--- a/tipg/sql/dbcatalog.sql
+++ b/tipg/sql/dbcatalog.sql
@@ -130,10 +130,10 @@ $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION pg_temp.tipg_fun_defaults(defaults pg_node_tree) RETURNS text[] AS $$
     WITH d AS (
-        SELECT btrim(split_part(btrim(string_to_table(
+        SELECT btrim(split_part(btrim(unnest(string_to_array(
                 pg_get_expr(defaults,0::oid),
                 ','
-        )),'::',1),'''') d
+        ))),'::',1),'''') d
     ) SELECT array_agg(d) FROM d
     ;
 $$ LANGUAGE SQL;


### PR DESCRIPTION
closes #67 

This PR replace `string_to_table(...)` by `unnest(string_to_array(...))` to support older postgres 


> string_to_table() provides the set-based equivalent to [string_to_array()](https://pgpedia.info/s/string_to_array.html), and is functionally the same albeit somewhat faster than [unnest](https://pgpedia.info/u/unnest.html)(string_to_array())

From PG docs: https://pgpedia.info/s/string_to_table.html

Note: we could also use `regexp_split_to_table` https://pgpedia.info/r/regexp_split_to_table.html which seems to give the same result 🤷 
