### PR TITLE
add items/item depencencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
         prev: Optional[int]
     ```
 
+- add `tipg.dependencies.ItemsParams` and `tipg.dependencies.ItemParams`
+
 ### fixed
 
 - hide map element in HTML pages when collections/items do not have spatial component (https://github.com/developmentseed/tipg/issues/132)
@@ -93,6 +95,7 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 - move `s_intersects` and `t_intersects` functions from `tipg.factory` to `tipg.dependencies`
 
+- add `items_dependency` and `item_dependency` attributes in `OGCFeaturesFactory` class. Those new dependencies define the input for the `/items` and `/items/{itemId}` endpoints
 
 ## [0.4.4] - 2023-10-03
 

--- a/docs/src/user_guide/factories.md
+++ b/docs/src/user_guide/factories.md
@@ -7,10 +7,21 @@ class Factory:
 
     collections_dependency: Callable
     collection_dependency: Callable
+    items_dependency: Callable
+    item_dependency: Callable
 
-    def __init__(self, collections_dependency: Callable, collection_dependency: Callable):
+    def __init__(
+        self,
+        collections_dependency: Callable,
+        collection_dependency: Callable,
+        items_dependency: Callable,
+        item_dependency: Callable,
+    ):
         self.collections_dependency = collections_dependency
         self.collection_dependency = collection_dependency
+        self.items_dependency = items_dependency
+        self.item_dependency = item_dependency
+
         self.router = APIRouter()
 
         self.register_routes()
@@ -35,17 +46,16 @@ class Factory:
         def items(
             request: Request,
             collection=Depends(self.collection_dependency),
+            item_list=Depends(self.items_dependency),
         ):
-            item_list = collection.features(...)
             ...
 
         @self.router.get("/collections/{collectionId}/items/{itemId}")
         def item(
             request: Request,
             collection=Depends(self.collection_dependency),
-            itemId: str = Path(..., description="Item identifier"),
+            feature=Depends(self.item_dependency)
         ):
-            item_list = collection.features(ids_filter=[itemId])
             ...
 
 
@@ -75,6 +85,10 @@ app.include_router(endpoints.router, tags=["OGC Features API"])
 - **collections_dependency** (Callable[..., tipg.collections.CollectionList]): Callable which return a CollectionList dictionary
 
 - **collection_dependency** (Callable[..., tipg.collections.Collection]): Callable which return a Collection instance
+
+- **items_dependency** (Callable[..., tipg.collections.ItemList]): Callable which return a ItemList dictionary
+
+- **item_dependency** (Callable[..., tipg.collections.Feature]): Callable which return a Feature dictionary
 
 - **with_common** (bool, optional): Create Full OGC Features API set of endpoints with OGC Common endpoints (landing `/` and conformance `/conformance`). Defaults to `True`
 
@@ -157,6 +171,10 @@ app.include_router(endpoints.router)
 - **collections_dependency** (Callable[..., tipg.collections.CollectionList]): Callable which return a CollectionList dictionary
 
 - **collection_dependency** (Callable[..., tipg.collections.Collection]): Callable which return a Collection instance
+
+- **items_dependency** (Callable[..., tipg.collections.ItemList]): Callable which return a ItemList dictionary
+
+- **item_dependency** (Callable[..., tipg.collections.Feature]): Callable which return a Feature dictionary
 
 - **supported_tms** (morecantile.TileMatrixSets): morecantile TileMatrixSets instance (holds a set of TileMatrixSet documents)
 


### PR DESCRIPTION
This PR adds dependencies for both `/items` and `/items/{itemID}` endpoints 

This will enable custom backend which could allow more/less query parameters 