### PR TITLE
make calculating spatial/datetime extents optional

### DIFF
--- a/docs/src/user_guide/configuration.md
+++ b/docs/src/user_guide/configuration.md
@@ -50,6 +50,8 @@ class: `tipg.settings.DatabaseSettings`
 prefix: **`TIPG_DB_`**
 
 - **SCHEMAS** (list of string): Named schemas, `tipg` can look for `Tables` or `Functions`. Default is `["public"]`
+- **SPATIAL_EXTENT** (bool): Calculate spatial extent of records. Default is `True`.
+- **DATETIME_EXTENT** (bool): Calculate temporal extent of records. Default is `True`.
 
 #### `Tables`
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,8 @@ def create_tipg_app(
             exclude_functions=db_settings.exclude_functions,
             exclude_function_schemas=db_settings.exclude_function_schemas,
             spatial=db_settings.only_spatial_tables,
+            spatial_extent=db_settings.spatial_extent,
+            datetime_extent=db_settings.datetime_extent,
         )
         yield
         await close_db_connection(app)
@@ -320,6 +322,56 @@ def app_myschema_public(database_url, monkeypatch):
         schemas=["myschema", "public"],
         exclude_function_schemas=["public"],
         only_spatial_tables=False,
+    )
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
+
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
+
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def app_no_extents(database_url, monkeypatch):
+    """Create APP with tables from `myschema` and `public` schema but without
+    calculating the spatial/datetime extents.
+
+    Available tables should come from `myschema` and `public` and functions from `pg_temp`.
+    """
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["myschema", "public"],
+        spatial_extent=False,
+        datetime_extent=False,
+    )
+    sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
+
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
+
+    with TestClient(app) as client:
+        yield client
+
+
+@pytest.fixture
+def app_no_spatial_extent(database_url, monkeypatch):
+    """Create APP with tables from `myschema` and `public` schema but without
+    calculating the spatial/datetime extents.
+
+    Available tables should come from `myschema` and `public` and functions from `pg_temp`.
+    """
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["myschema", "public"],
+        spatial_extent=False,
+        datetime_extent=True,
     )
     sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,6 +347,7 @@ def app_no_extents(database_url, monkeypatch):
         schemas=["myschema", "public"],
         spatial_extent=False,
         datetime_extent=False,
+        only_spatial_tables=False,
     )
     sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 
@@ -372,6 +373,7 @@ def app_no_spatial_extent(database_url, monkeypatch):
         schemas=["myschema", "public"],
         spatial_extent=False,
         datetime_extent=True,
+        only_spatial_tables=False,
     )
     sql_settings = CustomSQLSettings(custom_sql_directory=SQL_FUNCTIONS_DIRECTORY)
 

--- a/tests/routes/test_collections.py
+++ b/tests/routes/test_collections.py
@@ -299,6 +299,12 @@ def test_collections_no_extents(app_no_extents):
     ]  # default value
     assert not body["extent"].get("temporal")
 
+    # check a table with datetime column
+    response = app_no_extents.get("/collections/public.nongeo_data")
+    assert response.status_code == 200
+    body = response.json()
+    assert not body.get("extent")
+
 
 def test_collections_no_spatial_extent(app_no_spatial_extent):
     """Test /collections endpoint."""
@@ -314,3 +320,10 @@ def test_collections_no_spatial_extent(app_no_spatial_extent):
             90,
         ]
     ]
+
+    # check a table with datetime column
+    response = app_no_spatial_extent.get("/collections/public.nongeo_data")
+    assert response.status_code == 200
+    body = response.json()
+    assert not body["extent"].get("spatial")
+    assert body["extent"].get("temporal")

--- a/tests/routes/test_collections.py
+++ b/tests/routes/test_collections.py
@@ -281,3 +281,36 @@ def test_collections_empty(app_empty):
     assert response.status_code == 200
     body = response.json()
     assert not body["collections"]
+
+
+def test_collections_no_extents(app_no_extents):
+    """Test /collections endpoint."""
+    response = app_no_extents.get("/collections/public.landsat_wrs")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["crs"] == ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"]
+    assert body["extent"].get("spatial").get("bbox") == [
+        [
+            -180,
+            -90,
+            180,
+            90,
+        ]
+    ]  # default value
+    assert not body["extent"].get("temporal")
+
+
+def test_collections_no_spatial_extent(app_no_spatial_extent):
+    """Test /collections endpoint."""
+    response = app_no_spatial_extent.get("/collections/public.canada")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["crs"] == ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"]
+    assert body["extent"].get("spatial").get("bbox") == [
+        [
+            -180,
+            -90,
+            180,
+            90,
+        ]
+    ]

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -907,6 +907,8 @@ async def get_collection_index(  # noqa: C901
     exclude_functions: Optional[List[str]] = None,
     exclude_function_schemas: Optional[List[str]] = None,
     spatial: bool = True,
+    spatial_extent: bool = True,
+    datetime_extent: bool = True,
 ) -> Catalog:
     """Fetch Table and Functions index."""
     schemas = schemas or ["public"]
@@ -920,7 +922,9 @@ async def get_collection_index(  # noqa: C901
             :functions,
             :exclude_functions,
             :exclude_function_schemas,
-            :spatial
+            :spatial,
+            :spatial_extent,
+            :datetime_extent
         );
     """  # noqa: W605
 
@@ -935,6 +939,8 @@ async def get_collection_index(  # noqa: C901
             exclude_functions=exclude_functions,
             exclude_function_schemas=exclude_function_schemas,
             spatial=spatial,
+            spatial_extent=spatial_extent,
+            datetime_extent=datetime_extent,
         )
 
         catalog: Dict[str, Collection] = {}

--- a/tipg/main.py
+++ b/tipg/main.py
@@ -52,6 +52,8 @@ async def lifespan(app: FastAPI):
         exclude_functions=db_settings.exclude_functions,
         exclude_function_schemas=db_settings.exclude_function_schemas,
         spatial=db_settings.only_spatial_tables,
+        spatial_extent=db_settings.spatial_extent,
+        datetime_extent=db_settings.datetime_extent,
     )
 
     yield

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -50,7 +50,6 @@ class TableSettings(BaseSettings):
 
     fallback_key_names: List[str] = ["ogc_fid", "id", "pkey", "gid"]
     table_config: Dict[str, TableConfig] = {}
-    datetime_extent: bool = True
 
     model_config = {
         "env_prefix": "TIPG_",
@@ -158,6 +157,8 @@ class DatabaseSettings(BaseSettings):
     functions: Optional[List[str]] = None
     exclude_functions: Optional[List[str]] = None
     exclude_function_schemas: Optional[List[str]] = None
+    datetime_extent: bool = True
+    spatial_extent: bool = True
 
     only_spatial_tables: bool = True
 


### PR DESCRIPTION
As discussed in #139, Calculating the extent of spatial/datetime columns can be slow enough that serverless deployments of `tipg` are not possible.

Skipping the extent calculations is one way to make application startup almost instantaneous! With this change, the user can set `TIPG_DB_SPATIAL_EXTENT=False` and `TIPG_DB_DATETIME_EXTENT=False` to skip these calculations.

I am not sure if passing these arguments all the way through to `pg_temp.tipg_properties` is the best way to accomplish this, but I got it working. If there is a cleaner way that you can think of please let me know!