### PR TITLE
Fix decimal error again

### DIFF
--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -35,7 +35,7 @@ from tipg.dependencies import (
 )
 from tipg.errors import MissingGeometryColumn, NoPrimaryKey, NotFound
 from tipg.resources.enums import MediaType
-from tipg.resources.response import GeoJSONResponse, SchemaJSONResponse
+from tipg.resources.response import GeoJSONResponse, SchemaJSONResponse, orjsonDumps
 from tipg.settings import FeaturesSettings, MVTSettings, TMSSettings
 
 from fastapi import APIRouter, Depends, Path, Query
@@ -781,7 +781,7 @@ class OGCFeaturesFactory(EndpointsFactory):
                 # NDJSON Response
                 if output_type == MediaType.ndjson:
                     return StreamingResponse(
-                        (orjson.dumps(row) + b"\n" for row in rows),
+                        (orjsonDumps(row) + b"\n" for row in rows),
                         media_type=MediaType.ndjson,
                         headers={
                             "Content-Disposition": "attachment;filename=items.ndjson"
@@ -892,7 +892,7 @@ class OGCFeaturesFactory(EndpointsFactory):
             # GeoJSONSeq Response
             elif output_type == MediaType.geojsonseq:
                 return StreamingResponse(
-                    (orjson.dumps(f) + b"\n" for f in data["features"]),  # type: ignore
+                    (orjsonDumps(f) + b"\n" for f in data["features"]),  # type: ignore
                     media_type=MediaType.geojsonseq,
                     headers={
                         "Content-Disposition": "attachment;filename=items.geojson"
@@ -1016,7 +1016,7 @@ class OGCFeaturesFactory(EndpointsFactory):
                 # NDJSON Response
                 if output_type == MediaType.ndjson:
                     return StreamingResponse(
-                        (orjson.dumps(row) + b"\n" for row in rows),
+                        (orjsonDumps(row) + b"\n" for row in rows),
                         media_type=MediaType.ndjson,
                         headers={
                             "Content-Disposition": "attachment;filename=items.ndjson"
@@ -1512,7 +1512,6 @@ class OGCTilesFactory(EndpointsFactory):
             return Response(bytes(tile), media_type=MediaType.mvt.value)
 
     def _tilejson_routes(self):
-
         ############################################################################
         # ADDITIONAL ENDPOINTS NOT IN OGC Tiles API (tilejson, style.json, viewer) #
         ############################################################################

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -886,7 +886,7 @@ class OGCFeaturesFactory(EndpointsFactory):
             # HTML Response
             if output_type == MediaType.html:
                 return self._create_html_response(
-                    request, orjson.dumps(data).decode(), template_name="items"
+                    request, orjsonDumps(data).decode(), template_name="items"
                 )
 
             # GeoJSONSeq Response
@@ -1050,7 +1050,7 @@ class OGCFeaturesFactory(EndpointsFactory):
             if output_type == MediaType.html:
                 return self._create_html_response(
                     request,
-                    orjson.dumps(data).decode(),
+                    orjsonDumps(data).decode(),
                     template_name="item",
                 )
 

--- a/tipg/resources/response.py
+++ b/tipg/resources/response.py
@@ -14,16 +14,20 @@ def default(obj):
         return str(obj)
 
 
+def orjsonDumps(content: Any):
+    return orjson.dumps(
+        content,
+        default=default,
+        option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY,
+    )
+
+
 class ORJSONResponse(JSONResponse):
     """Custom response handler for using orjson"""
 
     def render(self, content: Any) -> bytes:
         """Render the content into a JSON response using orjson"""
-        return orjson.dumps(
-            content,
-            default=default,
-            option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY,
-        )
+        return orjsonDumps(content)
 
 
 class GeoJSONResponse(ORJSONResponse):

--- a/tipg/resources/response.py
+++ b/tipg/resources/response.py
@@ -15,6 +15,7 @@ def default(obj):
 
 
 def orjsonDumps(content: Any):
+    """Small wrapper function to run the orjson.dumps with the additional options we want"""
     return orjson.dumps(
         content,
         default=default,


### PR DESCRIPTION
Hey, we finally updated our version of tipg again and I discovered that my fix in pull request #89 was incomplete insofar that the web interface of tipg was also throwing the same error. So I extracted the orjson.dumps into a separate function so it can be used outside of the ORJSONResponse class as well

I think it doesn't require any new tests since the old tests for the decimal fix are still there and I assume the other responses are also already covered by tests. But if you want some stylistic changes or such just let me know :slightly_smiling_face: 