### PR TITLE
Patch/do not exclude null properties

### DIFF
--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -754,21 +754,27 @@ class OGCFeaturesFactory(EndpointsFactory):
                 MediaType.json,
                 MediaType.ndjson,
             ):
-                rows = (
-                    {
-                        **{
-                            k: v
-                            for k, v in {
-                                "collectionId": collection.id,
-                                "itemId": f.get("id"),
-                                "geometry": f.get("geometry", None),
-                            }.items()
-                            if v is not None
-                        },
-                        **f.get("properties", {}),
-                    }
-                    for f in item_list["items"]
-                )
+                if any(
+                    [f.get("geometry", None) is not None for f in item_list["items"]]
+                ):
+                    rows = (
+                        {
+                            "collectionId": collection.id,
+                            "itemId": f.get("id"),
+                            **f.get("properties", {}),
+                            "geometry": f.get("geometry", None),
+                        }
+                        for f in item_list["items"]
+                    )
+                else:
+                    rows = (
+                        {
+                            "collectionId": collection.id,
+                            "itemId": f.get("id"),
+                            **f.get("properties", {}),
+                        }
+                        for f in item_list["items"]
+                    )
 
                 # CSV Response
                 if output_type == MediaType.csv:

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -756,14 +756,16 @@ class OGCFeaturesFactory(EndpointsFactory):
             ):
                 rows = (
                     {
-                        k: v
-                        for k, v in {
-                            "collectionId": collection.id,
-                            "itemId": f.get("id"),
-                            **f.get("properties", {}),
-                            "geometry": f.get("geometry", None),
-                        }.items()
-                        if v is not None
+                        **{
+                            k: v
+                            for k, v in {
+                                "collectionId": collection.id,
+                                "itemId": f.get("id"),
+                                "geometry": f.get("geometry", None),
+                            }.items()
+                            if v is not None
+                        },
+                        **f.get("properties", {}),
                     }
                     for f in item_list["items"]
                 )


### PR DESCRIPTION
closes #159 

In the previous version (main) we were excluding `None` values, mostly to exclude empty geometries but sometimes it meant we were excluding valid properties, which could lead in `invalid` CSV headers (because row 1 and row 2 could have different properties, if row 1 had `None` property)