### PR TITLE
parse sub-model for table_settings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,10 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
 
-## [unreleased]
+## [0.6.0] - 2024-01-09
 
 - update FastAPI version lower limit to `>0.107.0` and adapt for new starlette version
 - fix invalid streaming response formatting
+- refactor internal table properties handling
+- fix sub-model Table settings (https://github.com/developmentseed/tipg/issues/154)
 
 ## [0.5.7] - 2024-01-08
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -558,3 +558,25 @@ def app_functions(database_url, monkeypatch):
 
     with TestClient(app) as client:
         yield client
+
+
+@pytest.fixture(autouse=True)
+def app_public_table(database_url, monkeypatch):
+    """Create app with connection to the pytest database."""
+    monkeypatch.setenv("TIPG_TABLE_CONFIG__public_landsat_wrs__properties", '["pr"]')
+
+    postgres_settings = PostgresSettings(database_url=database_url)
+    db_settings = DatabaseSettings(
+        schemas=["public"],
+        functions=[],
+    )
+    sql_settings = CustomSQLSettings(custom_sql_directory=None)
+
+    app = create_tipg_app(
+        postgres_settings=postgres_settings,
+        db_settings=db_settings,
+        sql_settings=sql_settings,
+    )
+
+    with TestClient(app) as client:
+        yield client

--- a/tests/routes/test_item.py
+++ b/tests/routes/test_item.py
@@ -38,3 +38,16 @@ def test_item(app):
     # not found
     response = app.get("/collections/public.landsat_wrs/items/50000")
     assert response.status_code == 404
+
+
+def test_item_with_property_config(app_public_table):
+    """Test /items/{item id} endpoint."""
+    response = app_public_table.get("/collections/public.landsat_wrs/items/1")
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/geo+json"
+    body = response.json()
+    assert body["type"] == "Feature"
+    assert body["id"] == 1
+    assert body["links"]
+    print(body["properties"])
+    Item.model_validate(body)

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -1,9 +1,11 @@
 """tipg config."""
 
+import json
 import pathlib
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import (
+    BaseModel,
     DirectoryPath,
     Field,
     PostgresDsn,
@@ -12,7 +14,6 @@ from pydantic import (
     model_validator,
 )
 from pydantic_settings import BaseSettings
-from typing_extensions import TypedDict
 
 
 class APISettings(BaseSettings):
@@ -36,13 +37,23 @@ class APISettings(BaseSettings):
         return [origin.strip() for origin in v.split(",")]
 
 
-class TableConfig(TypedDict, total=False):
+class TableConfig(BaseModel):
     """Configuration to add table options with env variables."""
 
-    geomcol: Optional[str]
-    datetimecol: Optional[str]
-    pk: Optional[str]
-    properties: Optional[List[str]]
+    geomcol: Optional[str] = None
+    datetimecol: Optional[str] = None
+    pk: Optional[str] = None
+    properties: Optional[List[str]] = None
+
+    model_config = {"extra": "ignore"}
+
+    @field_validator("properties", mode="before")
+    def _properties(cls, v: Any) -> Any:
+        """set geometry from geo interface or input"""
+        if isinstance(v, str):
+            return json.loads(v)
+        else:
+            return v
 
 
 class TableSettings(BaseSettings):


### PR DESCRIPTION
attempt to closes https://github.com/developmentseed/tipg/discussions/158

While I think this PR `fixes` the original issue, when I added tests I found a `bug`. If we don't include the `id_column` in the properties then the code fails when it tries to retrieve the `id_column_info` (because it's not in the properties list)