### PR TITLE
use spatial_extent and datetime_extent everywhere

### DIFF
--- a/tipg/main.py
+++ b/tipg/main.py
@@ -115,6 +115,8 @@ if settings.catalog_ttl:
         exclude_functions=db_settings.exclude_functions,
         exclude_function_schemas=db_settings.exclude_function_schemas,
         spatial=db_settings.only_spatial_tables,
+        spatial_extent=db_settings.spatial_extent,
+        datetime_extent=db_settings.datetime_extent,
     )
 
 add_exception_handlers(app, DEFAULT_STATUS_CODES)
@@ -152,5 +154,7 @@ if settings.debug:
             exclude_functions=db_settings.exclude_functions,
             exclude_function_schemas=db_settings.exclude_function_schemas,
             spatial=db_settings.only_spatial_tables,
+            spatial_extent=db_settings.spatial_extent,
+            datetime_extent=db_settings.datetime_extent,
         )
         return request.app.state.collection_catalog


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
- We added the `spatial_extent` and `datetime_extent` parameters to `register_collection_catalog` but they were only getting used in one of the calls to the function. After deploying `tipg` again on a database with some really large tables with spatial and temporal columns I realized that the extent calculations were still getting run but not at application startup!

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- pass the `spatial_extent` and `datetime_extent` settings to all calls to `register_collection_catalog` (not just the first one).

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
- #143 
