### PR TITLE
avoid serializing and deserializing when not necessary

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,9 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 ## [unreleased]
 
 - update leaflet version
+- add `templated=True` in template URL links
+- add `(Template URL)` in template URL links title
+- remove *deserialization* in `tipg.factory.create_html_response` function
 
 ## [0.6.3] - 2024-02-02
 

--- a/tests/test_factories.py
+++ b/tests/test_factories.py
@@ -30,7 +30,9 @@ def test_features_factory():
         landing_link = [link for link in links if link["title"] == "Landing Page"][0]
         assert landing_link["href"] == "http://testserver/"
         queryables_link = [
-            link for link in links if link["title"] == "Collection queryables"
+            link
+            for link in links
+            if link["title"] == "Collection queryables (Template URL)"
         ][0]
         assert (
             queryables_link["href"]
@@ -68,7 +70,9 @@ def test_features_factory():
         landing_link = [link for link in links if link["title"] == "Landing Page"][0]
         assert landing_link["href"] == "http://testserver/features/"
         queryables_link = [
-            link for link in links if link["title"] == "Collection queryables"
+            link
+            for link in links
+            if link["title"] == "Collection queryables (Template URL)"
         ][0]
         assert (
             queryables_link["href"]
@@ -214,7 +218,9 @@ def test_endpoints_factory():
         landing_link = [link for link in links if link["title"] == "Landing Page"][0]
         assert landing_link["href"] == "http://testserver/"
         queryables_link = [
-            link for link in links if link["title"] == "Collection queryables"
+            link
+            for link in links
+            if link["title"] == "Collection queryables (Template URL)"
         ][0]
         assert (
             queryables_link["href"]
@@ -256,7 +262,9 @@ def test_endpoints_factory():
         landing_link = [link for link in links if link["title"] == "Landing Page"][0]
         assert landing_link["href"] == "http://testserver/ogc/"
         queryables_link = [
-            link for link in links if link["title"] == "Collection queryables"
+            link
+            for link in links
+            if link["title"] == "Collection queryables (Template URL)"
         ][0]
         assert (
             queryables_link["href"]


### PR DESCRIPTION
This PR does:
- add `templated=True` for templated links 
- add `(Template URL)` in template URL title
- use `model_dump(exclude_none=True, mode="json")` instead of `mode=python` + deserialization 
