### PR TITLE
better handle router-prefix and root-path in HTML template

### DIFF
--- a/tipg/templates/collection.html
+++ b/tipg/templates/collection.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -11,7 +16,7 @@
     {% endif %} {% endfor %}
 
     <li class="ml-auto json-link">
-      <a target="_blank" href="{{ url }}?f=json">JSON</a>
+      <a target="_blank" href="{{ urlq }}f=json">JSON</a>
     </li>
   </ol>
 </nav>

--- a/tipg/templates/collections.html
+++ b/tipg/templates/collections.html
@@ -2,8 +2,8 @@
 
 {% set show_prev_link = false %}
 {% set show_next_link = false %}
-{%  if 'items?' in url %}
-  {% set urlq = url + '&' %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
   {% else %}
   {% set urlq = url + '?' %}
 {% endif %}
@@ -17,7 +17,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/conformance.html
+++ b/tipg/templates/conformance.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/item.html
+++ b/tipg/templates/item.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=geojson">GeoJSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=geojson">GeoJSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/items.html
+++ b/tipg/templates/items.html
@@ -2,8 +2,8 @@
 
 {% set show_prev_link = false %}
 {% set show_next_link = false %}
-{%  if 'items?' in url %}
-  {% set urlq = url + '&' %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
   {% else %}
   {% set urlq = url + '?' %}
 {% endif %}

--- a/tipg/templates/landing.html
+++ b/tipg/templates/landing.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/queryables.html
+++ b/tipg/templates/queryables.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=schemajson">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=schemajson">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/tilematrixset.html
+++ b/tipg/templates/tilematrixset.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/tilematrixsets.html
+++ b/tipg/templates/tilematrixsets.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/tileset.html
+++ b/tipg/templates/tileset.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 

--- a/tipg/templates/tilesets.html
+++ b/tipg/templates/tilesets.html
@@ -1,4 +1,9 @@
 {% include "header.html" %}
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
 
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
@@ -9,7 +14,7 @@
       {% endif %}
     {% endfor %}
 
-    <li class="ml-auto json-link"><a target="_blank" href="{{ url }}?f=json">JSON</a></li>
+    <li class="ml-auto json-link"><a target="_blank" href="{{ urlq }}f=json">JSON</a></li>
   </ol>
 </nav>
 


### PR DESCRIPTION
This PR does:
- add `title` to `create_html_response` method, in order to set the web page title
- add `**kwargs` to `create_html_response` method to allow custom object to be passed to the template
- fix url/path passed to the HTML template 
- fix HTML templates when passing QueryParameters 