### PR TITLE
revert to fastapi and update version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
 
-## [0.7.1] - 2025-05-07
+## [0.7.2] - 2024-08-27
+
+* move back to `fastapi` dependency
+
+## [0.7.1] - 2024-05-07
 
 * move to `fastapi-slim` to avoid unwanted dependencies
 
@@ -305,7 +309,10 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 - Initial release
 
-[unreleased]: https://github.com/developmentseed/tipg/compare/0.6.3...HEAD
+[unreleased]: https://github.com/developmentseed/tipg/compare/0.7.2...HEAD
+[0.7.1]: https://github.com/developmentseed/tipg/compare/0.7.1...0.7.2
+[0.7.1]: https://github.com/developmentseed/tipg/compare/0.7.0...0.7.1
+[0.7.0]: https://github.com/developmentseed/tipg/compare/0.6.3...0.7.0
 [0.6.3]: https://github.com/developmentseed/tipg/compare/0.6.2...0.6.3
 [0.6.2]: https://github.com/developmentseed/tipg/compare/0.6.1...0.6.2
 [0.6.1]: https://github.com/developmentseed/tipg/compare/0.6.0...0.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "orjson",
     "asyncpg>=0.23.0",
     "buildpg>=0.3",
-    "fastapi-slim",
+    "fastapi>=0.100.0",
     "jinja2>=2.11.2,<4.0.0",
     "morecantile>=5.0,<6.0",
     "pydantic>=2.4,<3.0",


### PR DESCRIPTION
FastAPI reverted their changed and now doesn't include *useless* dependencies https://github.com/fastapi/fastapi/discussions/11525 

we can move back to `fastapi` instead of `fastapi-slim` and also relaxe the version dependency! 