### PR TITLE
Added in environment variable for sorting/config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 Note: Minor version `0.X.0` update might break the API, It's recommended to pin `tipg` to minor version: `tipg>=0.1,<0.2`
 
+## Unreleased
+
+* add `TIPG_SORT_COLUMNS` settings to enable/disable columns sorting (default to `True`) (author @mattdiez-at, https://github.com/developmentseed/tipg/pull/187)
+
 ## [0.7.2] - 2024-08-27
 
 * move back to `fastapi` dependency
@@ -310,7 +314,7 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 - Initial release
 
 [unreleased]: https://github.com/developmentseed/tipg/compare/0.7.2...HEAD
-[0.7.1]: https://github.com/developmentseed/tipg/compare/0.7.1...0.7.2
+[0.7.2]: https://github.com/developmentseed/tipg/compare/0.7.1...0.7.2
 [0.7.1]: https://github.com/developmentseed/tipg/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/developmentseed/tipg/compare/0.6.3...0.7.0
 [0.6.3]: https://github.com/developmentseed/tipg/compare/0.6.2...0.6.3

--- a/docs/src/user_guide/configuration.md
+++ b/docs/src/user_guide/configuration.md
@@ -79,12 +79,12 @@ prefix: **`TIPG_`**
 
 - **DATETIME_EXTENT** (bool): Fetch datetime extent by going throught all rows. Default is `True`
 - **FALLBACK_KEY_NAMES** (list of string): Primary Key names to look for in the tables. Default is `["ogc_fid", "id", "pkey", "gid"]`
+- **SORT_COLUMNS** (bool): Sort the `columns` for a table alphabetically. Default is `True`.
 - **TABLE_CONFIG** (dict of `TableConfig`)
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _GEOMCOL** (str): Table's geometry/geography column name
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _DATETIMECOL** (str): Table's datetime column name
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _PK** (str): Table's primary key
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _PROPERTIES** (list of string): Select specific properties from table (for filtering and output)
-- **SORT_COLUMNS** (bool): Sort the `columns` for a table alphabetically. Default is `True`.
 
 ```bash
 TIPG_TABLE_CONFIG__pgstac_items__PK=id

--- a/docs/src/user_guide/configuration.md
+++ b/docs/src/user_guide/configuration.md
@@ -129,6 +129,7 @@ prefix: **`TIPG_`**
 
 - **DEFAULT_FEATURES_LIMIT** (int): Set the default `Limit` values for `/items` endpoint. Default is `10`
 - **MAX_FEATURES_PER_QUERY** (int): Set the maximum number of features the `/items` endpoint can return. Default is `10000`.
+- **SORT_COLUMNS** (bool): Sort the `columns` for a feature alphabetically. Default is `True`.
 
 ```bash
 TIPG_DEFAULT_FEATURES_LIMIT=1000 TIPG_MAX_FEATURES_PER_QUERY=2000

--- a/docs/src/user_guide/configuration.md
+++ b/docs/src/user_guide/configuration.md
@@ -84,6 +84,7 @@ prefix: **`TIPG_`**
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _DATETIMECOL** (str): Table's datetime column name
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _PK** (str): Table's primary key
     - **TABLE_CONFIG_ _ {schemaId}_{tableId} _ _PROPERTIES** (list of string): Select specific properties from table (for filtering and output)
+- **SORT_COLUMNS** (bool): Sort the `columns` for a table alphabetically. Default is `True`.
 
 ```bash
 TIPG_TABLE_CONFIG__pgstac_items__PK=id
@@ -129,7 +130,6 @@ prefix: **`TIPG_`**
 
 - **DEFAULT_FEATURES_LIMIT** (int): Set the default `Limit` values for `/items` endpoint. Default is `10`
 - **MAX_FEATURES_PER_QUERY** (int): Set the maximum number of features the `/items` endpoint can return. Default is `10000`.
-- **SORT_COLUMNS** (bool): Sort the `columns` for a feature alphabetically. Default is `True`.
 
 ```bash
 TIPG_DEFAULT_FEATURES_LIMIT=1000 TIPG_MAX_FEATURES_PER_QUERY=2000

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -955,7 +955,7 @@ async def get_collection_index(  # noqa: C901
                 columns = sorted(table.get("properties", []), key=lambda d: d["name"])
             else:
                 columns = table.get("properties", [])
-            
+
             properties_setting = table_conf.properties or [c["name"] for c in columns]
 
             # ID Column

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -951,7 +951,11 @@ async def get_collection_index(  # noqa: C901
             table_conf = table_confs.get(confid, TableConfig())
 
             # Make sure that any properties set in conf exist in table
-            columns = sorted(table.get("properties", []), key=lambda d: d["name"])
+            if features_settings.sort_columns:
+                columns = sorted(table.get("properties", []), key=lambda d: d["name"])
+            else:
+                columns = table.get("properties", [])
+            
             properties_setting = table_conf.properties or [c["name"] for c in columns]
 
             # ID Column

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -951,10 +951,9 @@ async def get_collection_index(  # noqa: C901
             table_conf = table_confs.get(confid, TableConfig())
 
             # Make sure that any properties set in conf exist in table
+            columns = table.get("properties", [])
             if features_settings.sort_columns:
-                columns = sorted(table.get("properties", []), key=lambda d: d["name"])
-            else:
-                columns = table.get("properties", [])
+                columns = sorted(columns, key=lambda d: d["name"])
 
             properties_setting = table_conf.properties or [c["name"] for c in columns]
 

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -952,7 +952,7 @@ async def get_collection_index(  # noqa: C901
 
             # Make sure that any properties set in conf exist in table
             columns = table.get("properties", [])
-            if features_settings.sort_columns:
+            if table_settings.sort_columns:
                 columns = sorted(columns, key=lambda d: d["name"])
 
             properties_setting = table_conf.properties or [c["name"] for c in columns]

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -62,7 +62,8 @@ class TableSettings(BaseSettings):
 
     fallback_key_names: List[str] = ["ogc_fid", "id", "pkey", "gid"]
     table_config: Dict[str, TableConfig] = {}
-
+    sort_columns: bool = True
+    
     model_config = {
         "env_prefix": "TIPG_",
         "env_file": ".env",
@@ -86,7 +87,6 @@ class FeaturesSettings(BaseSettings):
 
     default_features_limit: int = Field(10, ge=0)
     max_features_per_query: int = Field(10000, ge=0)
-    sort_columns: bool = True
 
     model_config = {"env_prefix": "TIPG_", "env_file": ".env", "extra": "ignore"}
 

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -86,6 +86,7 @@ class FeaturesSettings(BaseSettings):
 
     default_features_limit: int = Field(10, ge=0)
     max_features_per_query: int = Field(10000, ge=0)
+    sort_columns: bool = True
 
     model_config = {"env_prefix": "TIPG_", "env_file": ".env", "extra": "ignore"}
 

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -143,7 +143,9 @@ class PostgresSettings(BaseSettings):
 
     # https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/core/config.py#L42
     @field_validator("database_url", mode="before")
-    def assemble_db_connection(cls, v: Optional[str], info: ValidationInfo) -> PostgresDsn:
+    def assemble_db_connection(
+        cls, v: Optional[str], info: ValidationInfo
+    ) -> PostgresDsn:
         """Validate db url settings."""
         if isinstance(v, str):
             return PostgresDsn(v)

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -63,7 +63,7 @@ class TableSettings(BaseSettings):
     fallback_key_names: List[str] = ["ogc_fid", "id", "pkey", "gid"]
     table_config: Dict[str, TableConfig] = {}
     sort_columns: bool = True
-    
+
     model_config = {
         "env_prefix": "TIPG_",
         "env_file": ".env",
@@ -143,9 +143,7 @@ class PostgresSettings(BaseSettings):
 
     # https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/core/config.py#L42
     @field_validator("database_url", mode="before")
-    def assemble_db_connection(
-        cls, v: Optional[str], info: ValidationInfo
-    ) -> PostgresDsn:
+    def assemble_db_connection(cls, v: Optional[str], info: ValidationInfo) -> PostgresDsn:
         """Validate db url settings."""
         if isinstance(v, str):
             return PostgresDsn(v)


### PR DESCRIPTION
## Rationale

Column order is important for a few of the tables I work with and switching my users from their (database-defined) order to alphabetical caused a little shellshock. Essentially, getting this functionality will be the last part of our migration from a different feature server package.

## How it works

We add an environment variable `TIPG_SORT_COLUMNS` (which defaults to `True`). Set it to `False` to disable sorting of columns. It's essentially trivial code, plus accompanying docs and `Settings` model updates.

## Anything else?

Let me know if I need to add anything else here.