### PR TITLE
Use non-minified protomaps-leaflet@latest

### DIFF
--- a/tipg/templates/map.html
+++ b/tipg/templates/map.html
@@ -17,7 +17,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script src="https://files.dnr.state.mn.us/lib/bootstrap4/javascripts/bootstrap.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/leaflet.js"></script>
-    <script src="https://unpkg.com/protomaps-leaflet@latest/dist/protomaps-leaflet.min.js"></script>
+    <script src="https://unpkg.com/protomaps-leaflet@latest/dist/protomaps-leaflet.js"></script>
     <script src="https://unpkg.com/proj4@2.3.14/dist/proj4.js"></script>
     <script src="https://unpkg.com/proj4leaflet@1.0.2/src/proj4leaflet.js"></script>
   </head>


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
Swapped `https://unpkg.com/protomaps-leaflet@latest/dist/protomaps-leaflet.min.js` -> `https://unpkg.com/protomaps-leaflet@latest/dist/protomaps-leaflet.js` in `map.html` template.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
[Their docs](https://github.com/protomaps/protomaps-leaflet?tab=readme-ov-file#how-to-use) does not link to a minified version so I tried that.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
Test the viewer on `main` vs this branch.

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
Closes #189 