### PR TITLE
Adds the ability to use a schema other than pg_temp for installing catalog functions.

### DIFF
--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -910,8 +910,8 @@ async def get_collection_index(  # noqa: C901
 ) -> Catalog:
     """Fetch Table and Functions index."""
     schemas = schemas or ["public"]
-    PostgresSettings()
-    query = """
+    pg_settings = PostgresSettings()
+    query = f"""
         SELECT {pg_settings.tipg_schema}.tipg_catalog(
             :schemas,
             :tables,
@@ -940,7 +940,6 @@ async def get_collection_index(  # noqa: C901
             spatial_extent=spatial_extent,
             datetime_extent=datetime_extent,
         )
-        PostgresSettings()
         catalog: Dict[str, Collection] = {}
         table_settings = TableSettings()
         table_confs = table_settings.table_config
@@ -951,7 +950,7 @@ async def get_collection_index(  # noqa: C901
             table_id = table["schema"] + "." + table["name"]
             confid = table["schema"] + "_" + table["name"]
 
-            if table_id == "{pg_settings.tipg_schema}.tipg_catalog":
+            if table_id.split(".").pop() == "tipg_catalog":
                 continue
 
             table_conf = table_confs.get(confid, TableConfig())

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -25,7 +25,13 @@ from tipg.filter.evaluate import to_filter
 from tipg.filter.filters import bbox_to_wkt
 from tipg.logger import logger
 from tipg.model import Extent
-from tipg.settings import FeaturesSettings, MVTSettings, TableConfig, TableSettings
+from tipg.settings import (
+    FeaturesSettings,
+    MVTSettings,
+    PostgresSettings,
+    TableConfig,
+    TableSettings,
+)
 
 from fastapi import FastAPI
 
@@ -904,9 +910,9 @@ async def get_collection_index(  # noqa: C901
 ) -> Catalog:
     """Fetch Table and Functions index."""
     schemas = schemas or ["public"]
-
+    PostgresSettings()
     query = """
-        SELECT pg_temp.tipg_catalog(
+        SELECT {pg_settings.tipg_schema}.tipg_catalog(
             :schemas,
             :tables,
             :exclude_tables,
@@ -934,7 +940,7 @@ async def get_collection_index(  # noqa: C901
             spatial_extent=spatial_extent,
             datetime_extent=datetime_extent,
         )
-
+        PostgresSettings()
         catalog: Dict[str, Collection] = {}
         table_settings = TableSettings()
         table_confs = table_settings.table_config
@@ -945,7 +951,7 @@ async def get_collection_index(  # noqa: C901
             table_id = table["schema"] + "." + table["name"]
             confid = table["schema"] + "_" + table["name"]
 
-            if table_id == "pg_temp.tipg_catalog":
+            if table_id == "{pg_settings.tipg_schema}.tipg_catalog":
                 continue
 
             table_conf = table_confs.get(confid, TableConfig())

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -141,6 +141,8 @@ class PostgresSettings(BaseSettings):
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 
+    tipg_schema: str = Field("pg_temp", regex=r"[a-zA-Z][a-zA-Z0-9_-]*")
+
     # https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/core/config.py#L42
     @field_validator("database_url", mode="before")
     def assemble_db_connection(

--- a/tipg/settings.py
+++ b/tipg/settings.py
@@ -141,7 +141,7 @@ class PostgresSettings(BaseSettings):
 
     model_config = {"env_file": ".env", "extra": "ignore"}
 
-    tipg_schema: str = Field("pg_temp", regex=r"[a-zA-Z][a-zA-Z0-9_-]*")
+    tipg_schema: str = Field("pg_temp", pattern=r"[a-zA-Z][a-zA-Z0-9_-]*")
 
     # https://github.com/tiangolo/full-stack-fastapi-postgresql/blob/master/%7B%7Bcookiecutter.project_slug%7D%7D/backend/app/app/core/config.py#L42
     @field_validator("database_url", mode="before")


### PR DESCRIPTION
Adds the tipg_schema setting to PostgresSettings defaulting to "pg_temp" to allow installing tipg catalog functions into a permanent schema (NOTE: this schema must already exist, and the logged in user must have full permissions to the schema!).

Basically, this is just doing a replace of "pg_temp" in the dbcatalog.sql with whatever is set in the tipg_schema setting.