### PR TITLE
Fix CRS Transformation for custom TMS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ## [unreleased]
 
+## [0.10.0] - 2025-02-20
+
+* convert tile bbox into collection's CRS for `MVT` where selection (author @callsumzg, https://github.com/developmentseed/tipg/pull/205)
+
 ## [0.9.0] - 2025-01-17
 
 * fix serialization of UUID columns (author @giorgiobasile, https://github.com/developmentseed/tipg/pull/199)
@@ -331,7 +335,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 - Initial release
 
-[unreleased]: https://github.com/developmentseed/tipg/compare/0.9.0...HEAD
+[unreleased]: https://github.com/developmentseed/tipg/compare/0.10.0...HEAD
+[0.10.0]: https://github.com/developmentseed/tipg/compare/0.9.0...0.10.0
 [0.9.0]: https://github.com/developmentseed/tipg/compare/0.8.0...0.9.0
 [0.8.0]: https://github.com/developmentseed/tipg/compare/0.7.3...0.8.0
 [0.7.3]: https://github.com/developmentseed/tipg/compare/0.7.2...0.7.3

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -12,6 +12,7 @@ from ciso8601 import parse_rfc3339
 from morecantile import Tile, TileMatrixSet
 from pydantic import BaseModel, Field, model_validator
 from pygeofilter.ast import AstType
+from pyproj import Transformer
 
 from tipg.errors import (
     InvalidDatetime,
@@ -540,8 +541,6 @@ class Collection(BaseModel):
             # Use a fallback of 4326 if tms.crs.to_epsg() returns a falsey value.
             tms_epsg = tms.crs.to_epsg() or 4326
             if geometry_column.srid != tms_epsg:
-                from pyproj import Transformer
-
                 transformer = Transformer.from_crs(
                     tms_epsg, geometry_column.srid, always_xy=True
                 )

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -532,31 +532,36 @@ class Collection(BaseModel):
             wheres.append(to_filter(cql, [p.name for p in self.properties]))
 
         if tile and tms and geometry_column:
-            # Get Tile Bounds in Geographic CRS (usually epsg:4326)
-            left, bottom, right, top = tms.bounds(tile)
+            # Get tile bounds in the TMS coordinate system
+            bbox = tms.xy_bounds(tile)
+            left, bottom, right, top = bbox
 
-            # Truncate bounds to the max TMS bbox
-            left, bottom = tms.truncate_lnglat(left, bottom)
-            right, top = tms.truncate_lnglat(right, top)
+            # If the geometry column’s SRID does not match the TMS CRS, transform the bounds:
+            # Use a fallback of 4326 if tms.crs.to_epsg() returns a falsey value.
+            tms_epsg = tms.crs.to_epsg() or 4326
+            if geometry_column.srid != tms_epsg:
+                from pyproj import Transformer
+
+                transformer = Transformer.from_crs(
+                    tms_epsg, geometry_column.srid, always_xy=True
+                )
+                left, bottom = transformer.transform(left, bottom)
+                right, top = transformer.transform(right, top)
 
             wheres.append(
                 logic.Func(
                     "ST_Intersects",
                     logic.Func(
-                        "ST_Transform",
+                        "ST_Segmentize",
                         logic.Func(
-                            "ST_Segmentize",
-                            logic.Func(
-                                "ST_MakeEnvelope",
-                                left,
-                                bottom,
-                                right,
-                                top,
-                                4326,
-                            ),
-                            right - left,
+                            "ST_MakeEnvelope",
+                            left,
+                            bottom,
+                            right,
+                            top,
+                            geometry_column.srid,
                         ),
-                        pg_funcs.cast(geometry_column.srid, "int"),
+                        right - left,
                     ),
                     logic.V(geometry_column.name),
                 )

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -544,8 +544,10 @@ class Collection(BaseModel):
                 transformer = Transformer.from_crs(
                     tms_epsg, geometry_column.srid, always_xy=True
                 )
-                left, bottom = transformer.transform(left, bottom)
-                right, top = transformer.transform(right, top)
+
+                left, bottom, right, top = transformer.transform_bounds(
+                    left, bottom, right, top
+                )
 
             wheres.append(
                 logic.Func(

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -2,6 +2,7 @@
 
 import datetime
 import re
+from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, TypedDict, Union
 
 from buildpg import RawDangerous as raw
@@ -32,6 +33,8 @@ from fastapi import FastAPI
 
 mvt_settings = MVTSettings()
 features_settings = FeaturesSettings()
+
+TransformerFromCRS = lru_cache(Transformer.from_crs)
 
 
 def debug_query(q, *p):
@@ -541,7 +544,7 @@ class Collection(BaseModel):
             # Use a fallback of 4326 if tms.crs.to_epsg() returns a falsey value.
             tms_epsg = tms.crs.to_epsg() or 4326
             if geometry_column.srid != tms_epsg:
-                transformer = Transformer.from_crs(
+                transformer = TransformerFromCRS(
                     tms_epsg, geometry_column.srid, always_xy=True
                 )
 


### PR DESCRIPTION
# Summary
This PR fixes issues in the spatial filtering logic for tile generation, which were causing missing features when custom TMS are used.

# Problem Description
When creating tiles with a custom TMS that has a different CRS (e.g. EPSG 2056), TiPG is constructing two different bounding boxes that aren’t in sync. One envelope is produced directly in the target CRS (e.g. 2056) while the other is produced in EPSG:4326 and then transformed into 2056. Because the transformation (and the segmentize step) may not be perfectly invertible, these two envelopes don’t match. As a result, only features that lie inside the intersection of both envelopes get selected. This effect is visible when zooming far enough into the dataset.

## Example:
When using a custom TMS for EPSG 2056 data (in this example, contour lines), the following SQL query is executed by TiPG for tile 11/1031/509:

```sql
WITH t AS (SELECT hoehe, in_kanton, t_id, ST_AsMVTGeom(ST_Transform(geom::geometry, 2056::int), ST_Segmentize(ST_MakeEnvelope(2683931.75, 1219444.29, 2684187.75, 1219700.29), 256.0), 4096, 256, True) AS geom
FROM hoehenkurven_1700.hk_10m
WHERE True AND ST_Intersects(ST_Transform(ST_Segmentize(ST_MakeEnvelope(8.54586926745684, 47.121968944662434, 8.549195345831953, 47.12430421660828, 4326), 0.003326078375112118), 2056::int), geom)
LIMIT 10000)
SELECT ST_AsMVT(t.*, 'hk_10m') FROM t
```

The two bboxes created by TiPG the two ST_MakeEnvelope functions are not congruent. 
They are off center, and only the contour lines that intersect with both bboxes are getting tiled by TiPG (see Screenshot below):

<img width="1661" alt="Bug" src="https://github.com/user-attachments/assets/1f5b8828-5251-45bf-b3cf-0a82743ab7a5" />

To fix the bug we must ensure to use one consistent envelope (bounding box) for both the geometry transformation for ST_AsMVTGeom and the spatial filter (ST_Intersects). 

We should compute the envelope once in one coordinate system. 
In TiPG, the envelope used for filtering is built in the _where() method (in collections.py) using a hard-coded SRID of 4326, whereas the envelope passed into ST_AsMVTGeom is already in (or transformed to) the target CRS (2056 in this example). As a result, only features that lie in the intersection of these two (misaligned) envelopes are returned.

With this fix, the SQL query above changes to this:
```sql
WITH t AS (SELECT hoehe, in_kanton, t_id, ST_AsMVTGeom(ST_Transform(geom::geometry, 2056::int), ST_Segmentize(ST_MakeEnvelope(2683931.75, 1219444.29, 2684187.75, 1219700.29), 256.0), 4096, 256, True) AS geom
FROM hoehenkurven_1700.hk_10m
WHERE True AND ST_Intersects(ST_Segmentize(ST_MakeEnvelope(2683931.75, 1219444.29, 2684187.75, 1219700.29, 2056), 256.0), geom)
LIMIT 10000)
SELECT ST_AsMVT(t.*, 'hk_10m') FROM t
```






# Changes Made
- In the _where() method:
    - Tile bounds are now directly unpacked and, if the geometry column’s SRID doesn’t match the TMS EPSG (defaulting to 4326 when needed), they’re transformed using pyproj.Transformer. This ensures spatial queries work correctly across different SRIDs, 
    - remove hardcoded EPSG 4326

# Impact
This commit fixes the tile generation so that tiles with data in different CRSs are rendered correctly and the tile response is robustly parsed.
