### PR TITLE
feat: add extra property to collection and collection List

### DIFF
--- a/tipg/model.py
+++ b/tipg/model.py
@@ -1,7 +1,7 @@
 """tipg models."""
 
 from datetime import datetime
-from typing import Annotated, Dict, List, Literal, Optional, Set, Tuple, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Set, Tuple, Union
 
 from geojson_pydantic.features import Feature, FeatureCollection
 from morecantile.models import CRSType
@@ -145,6 +145,7 @@ class Collection(BaseModel):
     extent: Optional[Extent] = None
     itemType: str = "feature"
     crs: List[str] = ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"]
+    extraProperties: Optional[Dict[str, Any]] = None
 
     model_config = {"extra": "ignore"}
 


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
Add the ability to add extra parameters to collection and collectionList. Hence, they can be used to store metadata and extra information about the collection.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
In the current implementation of TiPg, a schema table in represents the whole collection and the rows represent items.
Since there is no separate table to store the collection data, If we add any columns with prefix "collection_properties_", we use that as extra properties.
A dependency injection is added which handles the above mentioned case.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
First ingest data with a column prefixing with "collection_properties_". Then, using the API docs, test if it shows up in the collection and collection list endpoints.