### PR TITLE
fix: switch to official python docker image over bitnami

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ## [unreleased]
 
+* switch to official python docker image from `bitnami`
+
 ## [1.2.1] - 2025-08-26
 
 * update `starlette-cramjam` requirement to `>=0.4,<0.6`

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,11 +1,11 @@
 ARG PYTHON_VERSION=3.12
 
-FROM bitnami/python:${PYTHON_VERSION}
+FROM python:${PYTHON_VERSION}
 RUN apt update && apt upgrade -y \
   && apt install curl -y \
   && rm -rf /var/lib/apt/lists/*
 
-  # Ensure root certificates are always updated at evey container build
+# Ensure root certificates are always updated at evey container build
 # and curl is using the latest version of them
 RUN mkdir /usr/local/share/ca-certificates/cacert.org
 RUN cd /usr/local/share/ca-certificates/cacert.org && curl -k -O https://www.cacert.org/certs/root.crt


### PR DESCRIPTION
# What this PR is

Switching to official python base image over `bitnami` because of their changes in access
