### PR TITLE
fix: Allow simplifying geometries in OGC Tiles API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ## [unreleased]
 
-* fix geometry simplification on OGC Tiles endpoints (author @guillemc23, https://github.com/developmentseed/tipg/pull/249)
+* add `simplify` option on OGC Tiles endpoints (author @guillemc23, https://github.com/developmentseed/tipg/pull/249)
 
 
 ## [1.3.0] - 2025-11-17

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ## [unreleased]
 
+* fix geometry simplification on OGC Tiles endpoints (author @guillemc23, https://github.com/developmentseed/tipg/pull/249)
+
+
 ## [1.3.0] - 2025-11-17
 
 * switch to official python docker image from `bitnami`

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -415,6 +415,13 @@ class PgCollection(Collection):
         """Create MVT from intersecting geometries."""
         geom = pg_funcs.cast(logic.V(geometry_column.name), "geometry")
 
+        if simplify:
+            geom = logic.Func(
+                "ST_Simplify",
+                geom,
+                simplify
+            )
+
         # make sure the geometries do not overflow the TMS bbox
         if not tms.is_valid(tile):
             geom = logic.Func(
@@ -866,6 +873,7 @@ class PgCollection(Collection):
         geom: Optional[str] = None,
         dt: Optional[str] = None,
         limit: Optional[int] = None,
+        simplify: Optional[float] = None,
     ):
         """Build query to get Vector Tile."""
         limit = limit or mvt_settings.max_features_per_tile
@@ -885,6 +893,7 @@ class PgCollection(Collection):
                 geometry_column=geometry_column,
                 tms=tms,
                 tile=tile,
+                simplify=simplify,
             ),
             self._from(function_parameters),
             self._where(

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -411,6 +411,7 @@ class PgCollection(Collection):
         geometry_column: Column,
         tms: TileMatrixSet,
         tile: Tile,
+        simplify: Optional[float],
     ):
         """Create MVT from intersecting geometries."""
         geom = pg_funcs.cast(logic.V(geometry_column.name), "geometry")

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -412,7 +412,6 @@ class PgCollection(Collection):
         tms: TileMatrixSet,
         tile: Tile,
         simplify: Optional[float],
-        preserve_topology: Optional[bool],
     ):
         """Create MVT from intersecting geometries."""
         geom = pg_funcs.cast(logic.V(geometry_column.name), "geometry")
@@ -420,7 +419,7 @@ class PgCollection(Collection):
         if simplify:
             geom = logic.Func(
                 "ST_SnapToGrid",
-                logic.Func("ST_SimplifyPreserveTopology" if preserve_topology else "ST_Simplify", geom, simplify),
+                logic.Func("ST_SimplifyPreserveTopology", geom, simplify),
                 simplify,
             )
 
@@ -876,7 +875,6 @@ class PgCollection(Collection):
         dt: Optional[str] = None,
         limit: Optional[int] = None,
         simplify: Optional[float] = None,
-        preserve_topology: Optional[bool] = None,
     ):
         """Build query to get Vector Tile."""
         limit = limit or mvt_settings.max_features_per_tile
@@ -897,7 +895,6 @@ class PgCollection(Collection):
                 tms=tms,
                 tile=tile,
                 simplify=simplify,
-                preserve_topology=preserve_topology,
             ),
             self._from(function_parameters),
             self._where(

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -1674,12 +1674,6 @@ class OGCTilesFactory(EndpointsFactory):
                     description="Simplify the output geometry to given threshold in the units of the output CRS.",
                 ),
             ] = None,
-            preserve_topology: Annotated[
-                Optional[bool],
-                Query(
-                    description="Whether to preserve the same topology as the original data when simplifying.",
-                ),
-            ] = None,
         ):
             """Return Vector Tile."""
             tms = self.supported_tms.get(tileMatrixSetId)
@@ -1701,7 +1695,6 @@ class OGCTilesFactory(EndpointsFactory):
                     geom=geom_column,
                     dt=datetime_column,
                     simplify=simplify,
-                    preserve_topology=preserve_topology,
                 )
 
             return Response(tile, media_type=MediaType.mvt.value)

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -1668,6 +1668,12 @@ class OGCTilesFactory(EndpointsFactory):
                     description="Limits the number of features in the response. Defaults to 10000 or TIPG_MAX_FEATURES_PER_TILE environment variable."
                 ),
             ] = None,
+            simplify: Annotated[
+                Optional[float],
+                Query(
+                    description="Simplify the output geometry to given threshold in decimal degrees.",
+                ),
+            ] = None,
         ):
             """Return Vector Tile."""
             tms = self.supported_tms.get(tileMatrixSetId)
@@ -1688,6 +1694,7 @@ class OGCTilesFactory(EndpointsFactory):
                     limit=limit,
                     geom=geom_column,
                     dt=datetime_column,
+                    simplify=simplify
                 )
 
             return Response(tile, media_type=MediaType.mvt.value)

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -1671,7 +1671,7 @@ class OGCTilesFactory(EndpointsFactory):
             simplify: Annotated[
                 Optional[float],
                 Query(
-                    description="Simplify the output geometry to given threshold in decimal degrees.",
+                    description="Simplify the output geometry to given threshold in the units of the output CRS.",
                 ),
             ] = None,
         ):

--- a/tipg/factory.py
+++ b/tipg/factory.py
@@ -1674,6 +1674,12 @@ class OGCTilesFactory(EndpointsFactory):
                     description="Simplify the output geometry to given threshold in the units of the output CRS.",
                 ),
             ] = None,
+            preserve_topology: Annotated[
+                Optional[bool],
+                Query(
+                    description="Whether to preserve the same topology as the original data when simplifying.",
+                ),
+            ] = None,
         ):
             """Return Vector Tile."""
             tms = self.supported_tms.get(tileMatrixSetId)
@@ -1694,7 +1700,8 @@ class OGCTilesFactory(EndpointsFactory):
                     limit=limit,
                     geom=geom_column,
                     dt=datetime_column,
-                    simplify=simplify
+                    simplify=simplify,
+                    preserve_topology=preserve_topology,
                 )
 
             return Response(tile, media_type=MediaType.mvt.value)


### PR DESCRIPTION
Hi everybody!

I believe there is a bug on the **OGC Tiles API** when simplifying the geometry. This possibility is documented in the official docs (https://developmentseed.org/tipg/user_guide/endpoints/#vector-tiles) but the behavior does not seem to be implemented.

I implemented the feature with small changes on the codebase, but I'm not sure if this is your ideal solution, though it works flawlessly. The only thing I haven't managed is to be coherent with the units, since in the other endpoints this simplify magnitude is given in degrees, but in this case it gets applied in meters (might be related with order of operations).

I would appreciate some input if on this feature :)

PS: I have noticed that `bbox_only` is also documented but not implemented.