### PR TITLE
fix: apply sortby when building vector tiles

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Note: Minor version `0.X.0` update might break the API, It's recommended to pin 
 
 ## [unreleased]
 
+* fix: apply `sortby` when building vector tiles. `Collection.get_tile()` accepted the parameter but never used it, so `?sortby=` had no effect on the order of features within a tile. The ordering is applied inside the `ST_AsMVT` aggregate, which also makes `limit` truncation deterministic. An invalid sort column now returns a `404` on the tile endpoint, as it already did on `/items`
+
 ## [1.6.0] - 2026-09-02
 
 * change: update `morecantile` dependency to `>=7.0,<8.0`

--- a/docs/src/user_guide/endpoints.md
+++ b/docs/src/user_guide/endpoints.md
@@ -629,11 +629,15 @@ QueryParams:
 - **filter-lang** (str, one of [`cql2-text`, `cql2-json`]): `Filter` language. Defaults to `cql2-text`.
 - **geom-column** * (str): Select geometry column to apply filter on and to create geometry from.
 - **datetime-column** * (str): Select datetime column to apply filter on.
-- **sortby** (str): Sort the items by a specific column (ascending (default) or descending). argument should be in form of `-/+{column}`.
+- **sortby** (str): Sort the features within the tile by a specific column (ascending (default) or descending). argument should be in form of `-/+{column}`. This controls the order features appear in the vector tile, which is the only draw-order control available to renderers such as deck.gl, and it also decides which features are kept when a tile exceeds `limit`. The sort column must be present in **properties** when that parameter is used.
 - **bbox-only**  * (bool): Only return the bounding box of the feature.
 - **simplify** * (float): Simplify the output geometry to given threshold in decimal degrees.
 
 \*  **Not in OGC API Features Specification**
+
+Example:
+
+- `http://127.0.0.1:8081/collections/public.countries/tiles/WebMercatorQuad/0/0/0?sortby=pop_est` *ascending, so the most populous countries are drawn last and sit on top of the others*
 
 
 ### Tileset list

--- a/tests/routes/test_tiles.py
+++ b/tests/routes/test_tiles.py
@@ -124,6 +124,38 @@ def test_tile(app):
     mvt_settings.set_mvt_layername = init_value
 
 
+def test_tile_sortby(app):
+    """Features inside a tile are ordered by `sortby`."""
+    init_value = mvt_settings.set_mvt_layername
+    mvt_settings.set_mvt_layername = False
+
+    url = "/collections/public.landsat_wrs/tiles/WebMercatorQuad/0/0/0?limit=100&properties=ogc_fid"
+
+    response = app.get(f"{url}&sortby=ogc_fid")
+    assert response.status_code == 200
+    decoded = mapbox_vector_tile.decode(response.content)
+    asc = [f["properties"]["ogc_fid"] for f in decoded["default"]["features"]]
+    assert len(asc) == 100
+    assert asc == sorted(asc)
+
+    response = app.get(f"{url}&sortby=-ogc_fid")
+    assert response.status_code == 200
+    decoded = mapbox_vector_tile.decode(response.content)
+    desc = [f["properties"]["ogc_fid"] for f in decoded["default"]["features"]]
+    assert len(desc) == 100
+    assert desc == sorted(desc, reverse=True)
+
+    mvt_settings.set_mvt_layername = init_value
+
+
+def test_tile_sortby_invalid_column(app):
+    """An unknown `sortby` column is rejected, as it is on /items."""
+    response = app.get(
+        "/collections/public.landsat_wrs/tiles/WebMercatorQuad/0/0/0?sortby=not_a_real_column"
+    )
+    assert response.status_code == 404
+
+
 def test_tile_custom_name(app):
     """Test custom layer name."""
     init_value = mvt_settings.set_mvt_layername

--- a/tests/routes/test_tiles.py
+++ b/tests/routes/test_tiles.py
@@ -1,8 +1,11 @@
 """Test Tiles endpoints."""
 
+import re
+
 import mapbox_vector_tile
 import numpy as np
 
+from tipg import collections
 from tipg.collections import mvt_settings
 
 
@@ -154,6 +157,41 @@ def test_tile_sortby_invalid_column(app):
         "/collections/public.landsat_wrs/tiles/WebMercatorQuad/0/0/0?sortby=not_a_real_column"
     )
     assert response.status_code == 404
+
+
+def test_tile_sortby_orders_inside_the_mvt_aggregate(app, monkeypatch):
+    """The ORDER BY must sit inside the ST_AsMVT call, not only in the CTE.
+
+    A CTE has not been an optimisation fence since PG12 — it can be inlined
+    and a parallel plan may reorder freely. PostgreSQL only guarantees the
+    order rows reach an aggregate when the ORDER BY is inside the aggregate
+    call itself, so a CTE-level ORDER BY can silently regress.
+    """
+    queries = []
+    monkeypatch.setattr(collections, "debug_query", lambda q, *p: queries.append(q))
+
+    response = app.get(
+        "/collections/public.landsat_wrs/tiles/WebMercatorQuad/0/0/0"
+        "?limit=10&properties=ogc_fid&sortby=-ogc_fid"
+    )
+    assert response.status_code == 200
+
+    sql = next(q for q in queries if "ST_AsMVT" in q)
+    assert re.search(r"ST_AsMVT\([^()]*ORDER BY", sql), sql
+
+
+def test_tile_sortby_column_must_be_selected(app):
+    """Sorting by a column excluded from `properties` is rejected, not ignored.
+
+    The aggregate can only order by columns present in its input row, so a
+    sort column that `properties` filters out cannot be honoured.
+    """
+    response = app.get(
+        "/collections/public.landsat_wrs/tiles/WebMercatorQuad/0/0/0"
+        "?properties=pr&sortby=ogc_fid"
+    )
+    assert response.status_code == 404
+    assert "ogc_fid" in response.json()["detail"]
 
 
 def test_tile_custom_name(app):

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -1010,6 +1010,7 @@ class PgCollection(Collection):
                 ),
                 self._from(function_parameters, params),
                 self._where_clause(where_filter),
+                self._sortby(sortby),
                 f"LIMIT {int(limit)}",
             ]
         )

--- a/tipg/collections.py
+++ b/tipg/collections.py
@@ -791,10 +791,14 @@ class PgCollection(Collection):
                 args.append(f"CAST(CAST(${len(params)} AS text) AS {p.type})")
         return f"FROM {name}({', '.join(args)})"
 
-    def _sortby(self, sortby: Optional[str]) -> str:
-        """Build the ORDER BY clause."""
-        sorts = []
+    def _sort_expressions(self, sortby: Optional[str]) -> List[Tuple[str, str]]:
+        """Parse ``sortby`` into ``(column name, SQL fragment)`` pairs.
+
+        The column name is returned alongside the fragment so callers can
+        check it against the columns they actually project.
+        """
         if sortby:
+            sorts = []
             for s in sortby.strip().split(","):
                 parts = re.match("^(?P<direction>[+-]?)(?P<column>.*)$", s).groupdict()  # type:ignore
 
@@ -803,13 +807,21 @@ class PgCollection(Collection):
                 if not self.get_column(column):
                     raise InvalidPropertyName(f"Property {column} does not exist.")
                 col_sql = _quote_ident(column)
-                sorts.append(f"{col_sql} DESC" if direction == "-" else col_sql)
-        elif self.id_column is not None:
-            sorts.append(_quote_ident(self.id_column.name))
-        else:
-            sorts.append(_quote_ident(self.properties[0].name))
+                sorts.append(
+                    (column, f"{col_sql} DESC" if direction == "-" else col_sql)
+                )
+            return sorts
 
-        return "ORDER BY " + ", ".join(sorts)
+        if self.id_column is not None:
+            column = self.id_column.name
+        else:
+            column = self.properties[0].name
+
+        return [(column, _quote_ident(column))]
+
+    def _sortby(self, sortby: Optional[str]) -> str:
+        """Build the ORDER BY clause."""
+        return "ORDER BY " + ", ".join(sql for _, sql in self._sort_expressions(sortby))
 
     @staticmethod
     def _where_clause(where: Optional[Expr]) -> str:
@@ -998,6 +1010,9 @@ class PgCollection(Collection):
             tile=tile,
         )
 
+        sorts = self._sort_expressions(sortby)
+        order_by = "ORDER BY " + ", ".join(sql for _, sql in sorts)
+
         params: List[Any] = []
         inner_sql = " ".join(
             [
@@ -1010,14 +1025,29 @@ class PgCollection(Collection):
                 ),
                 self._from(function_parameters, params),
                 self._where_clause(where_filter),
-                self._sortby(sortby),
+                order_by,
                 f"LIMIT {int(limit)}",
             ]
         )
 
+        # The ORDER BY above makes LIMIT truncation deterministic, but it does
+        # not fix the order rows reach ST_AsMVT: a CTE has not been an
+        # optimisation fence since PG12, so it can be inlined and a parallel
+        # plan may reorder freely. Only an ORDER BY *inside* the aggregate call
+        # guarantees the feature order in the tile. It can only reference
+        # columns of ``t``, so an explicit sort column must be projected.
+        aggregate_order = ""
+        if sortby:
+            selected = self.columns(properties)
+            if missing := [col for col, _ in sorts if col not in selected]:
+                raise InvalidPropertyName(
+                    f"Cannot sort by {', '.join(missing)}: not in the selected `properties`."
+                )
+            aggregate_order = f" {order_by}"
+
         layer = self.table if mvt_settings.set_mvt_layername is True else "default"
         params.append(layer)
-        sql = f"WITH t AS ({inner_sql}) SELECT ST_AsMVT(t.*, ${len(params)}) FROM t"
+        sql = f"WITH t AS ({inner_sql}) SELECT ST_AsMVT(t.*, ${len(params)}{aggregate_order}) FROM t"
         debug_query(sql, *params)
 
         tile = await conn.fetchval(sql, *params)


### PR DESCRIPTION
`Collection.get_tile()` accepts a `sortby` argument and never uses it, so `?sortby=` has no effect on vector tiles. `/items` sorts correctly; `/tiles` silently drops the parameter. Feature order inside an MVT is the only draw-order control renderers such as deck.gl have, so overlapping polygons stack arbitrarily. Present in every released version I checked (1.0.0 through 1.6.0).

### Decisions

**ORDER BY goes before `LIMIT`.** Beyond fixing feature order, this makes truncation deterministic — `LIMIT` with no `ORDER BY` currently keeps an arbitrary subset once a tile exceeds `tipg_max_features_per_tile`.

**Applied unconditionally, not only when `sortby` is passed.** With no `sortby`, `_sortby()` already falls back to the primary key, so this matches `/items`. It adds a sort to the default path in exchange for deterministic truncation. Happy to gate it on `sortby` if you would rather not pay that.

**Ordering is repeated inside the `ST_AsMVT` aggregate.** PostgreSQL only guarantees the order rows reach an aggregate when the `ORDER BY` is inside the aggregate call. The CTE-level `ORDER BY` does work today, because the `LIMIT` forces the sort to be kept — but that protection is incidental, and the failure mode is a silent `200` with wrongly stacked features. To be clear about how strong this is: I could not construct a plan that actually reorders, so this is insurance, not an observed fix. No measurable cost (timings overlap fully).

**Only an explicit `sortby` adds the aggregate `ORDER BY`.** The primary-key default keeps the CTE ordering alone, so existing `properties=`-restricted requests are unaffected.

**A sort column excluded by `properties=` is rejected rather than silently unsorted.** The aggregate can only order by columns present in its input row. The alternative — quietly widening the projection — would return a property the caller explicitly excluded. Raises `InvalidPropertyName` (404), consistent with how `/items` treats an unknown column.

**`_sortby()` split into `_sort_expressions()`,** which returns `(column, SQL fragment)` pairs so `get_tile()` can reuse one parse for the CTE, the aggregate, and the projection check. `_sortby()` is now a thin wrapper; its existing callers are unchanged.

### Behaviour changes

- Invalid sort column on `/tiles`: `200` (ignored) → `404`, matching `/items`
- `?properties=x&sortby=y` where `y` is not in `x`: `200` unsorted → `404`
- Tile feature order now follows `sortby`; `LIMIT` truncation is deterministic

### Testing

Four tests, each watched fail against `main` first. Full suite passes (106 → 108).

Also verified against real data (NOAA HMS smoke polygons, 932 features, three overlapping density classes). Counting features drawn after something heavier was already down, on one tile of 257 features:

| query | buried |
|---|---|
| no `sortby` | 167 / 257 |
| `sortby=density_rank` | 0 |


>[!NOTE]
> This supports the AIR4US work for visualizing HMS smoke data. The vector tiles have density property - denser features should be drawn on top of overlapping less dense features. Even though `sortby` is advertised as a query param for tiles, it isn't honored.